### PR TITLE
Initialize Next.js structure with demo cards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+ADMIN_USERNAMES=daniil123,kate_dev,ivan_qalead

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+.env
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # speakersPlatformSD
-Платформа для спикеров SD
+
+Телеграм Mini App для витрины выступлений спикеров.
+
+## Запуск локально
+
+```bash
+npm install
+npm run dev
+```
+
+Создайте `.env` на основе `.env.example` и заполните ключи Supabase.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "speakers-platform",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-swipeable": "7.0.0",
+    "@supabase/supabase-js": "2.38.5"
+  },
+  "devDependencies": {
+    "typescript": "5.4.4",
+    "tailwindcss": "3.4.4",
+    "postcss": "8.4.38",
+    "autoprefixer": "10.4.16"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/icon.png
+++ b/public/icon.png
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+  <rect width="96" height="96" fill="#ccc" />
+  <text x="48" y="52" font-size="24" text-anchor="middle" fill="#555">SP</text>
+</svg>

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+  <rect width="96" height="96" fill="#ccc" />
+  <text x="48" y="52" font-size="24" text-anchor="middle" fill="#555">SP</text>
+</svg>

--- a/src/components/AdminForm.tsx
+++ b/src/components/AdminForm.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const AdminForm: React.FC = () => {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Админская форма</h1>
+      <p>Тут будет форма редактирования спикеров и докладов.</p>
+    </div>
+  );
+};

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Talk, Speaker } from '../types/supabase';
+import { useSwipeable } from 'react-swipeable';
+
+interface Props {
+  talk: Talk & { speaker: Speaker };
+}
+
+export const Card: React.FC<Props> = ({ talk }) => {
+  const handlers = useSwipeable({
+    onSwipedLeft: () => {},
+    onSwipedRight: () => {},
+  });
+
+  const directionColors: Record<Talk['direction'], string> = {
+    frontend: 'bg-green-200',
+    backend: 'bg-red-200',
+    QA: 'bg-yellow-200',
+    mobile: 'bg-purple-200',
+    product: 'bg-orange-200',
+    data: 'bg-blue-200',
+    manager: 'bg-pink-200',
+  };
+
+  const color = directionColors[talk.direction];
+
+  return (
+    <div
+      {...handlers}
+      className={`p-4 rounded-xl shadow-md ${color} flex flex-col gap-2 min-w-[250px]`}
+    >
+      <img src={talk.speaker.photoUrl} alt={talk.speaker.name} className="w-full h-40 object-cover rounded-md" />
+      <h2 className="text-xl font-bold">{talk.speaker.name}</h2>
+      <h3 className="text-lg font-semibold">{talk.title}</h3>
+      <p className="text-sm">{talk.description}</p>
+      <p className="text-sm italic">{talk.eventName}</p>
+      {talk.status === 'past' ? (
+        <a
+          href={talk.recordingLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-700 underline"
+        >
+          Смотреть запись
+        </a>
+      ) : (
+        <>
+          <p className="text-sm">{talk.date}</p>
+          <a
+            href={talk.registrationLink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-700 underline"
+          >
+            Регистрация
+          </a>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface Props {
+  direction: string;
+  status: string;
+  setDirection: (d: string) => void;
+  setStatus: (s: string) => void;
+}
+
+const directions = ['all', 'frontend', 'backend', 'QA', 'mobile', 'product', 'data', 'manager'];
+const statuses = ['all', 'past', 'upcoming'];
+
+export const FilterBar: React.FC<Props> = ({ direction, status, setDirection, setStatus }) => {
+  return (
+    <div className="flex gap-2 p-2 overflow-x-auto">
+      <select value={direction} onChange={(e) => setDirection(e.target.value)} className="p-2 rounded">
+        {directions.map((d) => (
+          <option key={d} value={d}>
+            {d}
+          </option>
+        ))}
+      </select>
+      <select value={status} onChange={(e) => setStatus(e.target.value)} className="p-2 rounded">
+        {statuses.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+import { AdminForm } from '../components/AdminForm';
+import { getUsername, expand } from '../utils/telegram';
+
+const allowedUsers = (process.env.ADMIN_USERNAMES || '').split(',');
+
+const AdminPage: React.FC = () => {
+  const [allowed, setAllowed] = useState(false);
+
+  useEffect(() => {
+    expand();
+    const username = getUsername();
+    if (username && allowedUsers.includes(username)) {
+      setAllowed(true);
+    }
+  }, []);
+
+  if (!allowed) {
+    return <p className="p-4">Доступ запрещён</p>;
+  }
+
+  return <AdminForm />;
+};
+
+export default AdminPage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { Card } from '../components/Card';
+import { FilterBar } from '../components/FilterBar';
+import { fetchSpeakers, fetchTalks } from '../utils/api';
+import { Talk, Speaker } from '../types/supabase';
+import { expand } from '../utils/telegram';
+
+interface TalkWithSpeaker extends Talk {
+  speaker: Speaker;
+}
+
+const testSpeakers: Speaker[] = [
+  {
+    id: '1',
+    name: 'Иван Иванов',
+    photoUrl: 'https://via.placeholder.com/150',
+    description: 'Frontend разработчик',
+  },
+];
+
+const testTalks: Talk[] = [
+  {
+    id: 't1',
+    speakerId: '1',
+    title: 'Реактивный фронтенд',
+    description: 'Всё о React',
+    eventName: 'Frontend Conf',
+    direction: 'frontend',
+    status: 'upcoming',
+    date: '2024-08-10',
+    registrationLink: 'https://example.com',
+  },
+];
+
+const HomePage: React.FC = () => {
+  const [direction, setDirection] = useState('all');
+  const [status, setStatus] = useState('all');
+  const [talks, setTalks] = useState<TalkWithSpeaker[]>([]);
+
+  useEffect(() => {
+    expand();
+    // Здесь будет загрузка данных с сервера
+    const combined = testTalks.map((talk) => ({
+      ...talk,
+      speaker: testSpeakers.find((s) => s.id === talk.speakerId)!,
+    }));
+    setTalks(combined);
+  }, []);
+
+  const filtered = talks.filter((t) => {
+    return (
+      (direction === 'all' || t.direction === direction) &&
+      (status === 'all' || t.status === status)
+    );
+  });
+
+  return (
+    <div className="p-4">
+      <FilterBar direction={direction} status={status} setDirection={setDirection} setStatus={setStatus} />
+      <div className="flex gap-4 overflow-x-auto py-4">
+        {filtered.map((talk) => (
+          <Card key={talk.id} talk={talk} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,32 @@
+export type Speaker = {
+  id: string;
+  name: string;
+  photoUrl: string;
+  description?: string;
+};
+
+export type Talk = {
+  id: string;
+  speakerId: string;
+  title: string;
+  description: string;
+  eventName: string;
+  direction: 'frontend' | 'backend' | 'QA' | 'mobile' | 'product' | 'data' | 'manager';
+  status: 'past' | 'upcoming';
+  date?: string;
+  registrationLink?: string;
+  recordingLink?: string;
+};
+
+export type Database = {
+  public: {
+    Tables: {
+      speakers: {
+        Row: Speaker;
+      };
+      talks: {
+        Row: Talk;
+      };
+    };
+  };
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,19 @@
+import { supabase } from '../lib/supabaseClient';
+import type { Database } from '../types/supabase';
+
+export const fetchTalks = async () => {
+  const { data, error } = await supabase
+    .from('talks')
+    .select('*')
+    .order('date', { ascending: false });
+  if (error) throw error;
+  return data as Database['public']['Tables']['talks']['Row'][];
+};
+
+export const fetchSpeakers = async () => {
+  const { data, error } = await supabase
+    .from('speakers')
+    .select('*');
+  if (error) throw error;
+  return data as Database['public']['Tables']['speakers']['Row'][];
+};

--- a/src/utils/telegram.ts
+++ b/src/utils/telegram.ts
@@ -1,0 +1,9 @@
+export const tg = typeof window !== 'undefined' && (window as any).Telegram?.WebApp;
+
+export const getUsername = (): string | undefined => {
+  return tg?.initDataUnsafe?.user?.username;
+};
+
+export const expand = () => {
+  tg?.expand();
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/telegram-webapp-manifest.json
+++ b/telegram-webapp-manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "Speakers Platform",
+  "description": "Витрина выступлений спикеров",
+  "short_name": "Speakers",
+  "icons": [
+    {
+      "src": "icon.png",
+      "sizes": "96x96",
+      "type": "image/png"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js project with TypeScript and Tailwind
- add Telegram utils and Supabase client
- create card, filter bar and admin form components
- implement showcase and admin pages with test data
- provide example env vars and basic README

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685eaa18965883288e36aac45acb8c01