### PR TITLE
Add cartoon style SpeakerCard component

### DIFF
--- a/public/pattern.svg
+++ b/public/pattern.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
+  <path d="M0 80L80 0H60L0 60V80Z" fill="white" fill-opacity="0.4"/>
+  <path d="M20 80L80 20V0L0 80H20Z" fill="white" fill-opacity="0.4"/>
+</svg>

--- a/src/components/SpeakerCard.tsx
+++ b/src/components/SpeakerCard.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+interface Speaker {
+  name: string;
+  photoUrl: string;
+}
+
+interface Talk {
+  title: string;
+  description: string;
+  eventName: string;
+  status: 'past' | 'upcoming';
+  date?: string;
+  registrationLink?: string;
+  recordingLink?: string;
+}
+
+interface SpeakerCardProps {
+  speaker: Speaker;
+  talk: Talk;
+  /**
+   * Tailwind gradient classes, e.g. "from-yellow-400 via-pink-400 to-red-500"
+   */
+  gradient?: string;
+}
+
+export const SpeakerCard: React.FC<SpeakerCardProps> = ({
+  speaker,
+  talk,
+  gradient = 'from-yellow-300 via-pink-400 to-pink-600',
+}) => {
+  const badgeLabel = talk.status === 'past' ? 'Прошло' : 'Будет';
+  const link =
+    talk.status === 'past' ? talk.recordingLink : talk.registrationLink;
+  const buttonLabel =
+    talk.status === 'past' ? 'Смотреть запись' : 'Регистрация';
+
+  const openLink = () => {
+    if (link) {
+      window.open(link, '_blank');
+    }
+  };
+
+  return (
+    <div
+      className={`relative rounded-2xl shadow-xl p-4 text-center overflow-hidden bg-gradient-to-br ${gradient}`}
+    >
+      <div className="absolute inset-0 bg-[url('/pattern.svg')] opacity-20 pointer-events-none rounded-2xl" />
+      <span
+        className="absolute top-4 right-4 bg-purple-600 text-white text-xs font-bold px-3 py-1 rounded-full"
+      >
+        {badgeLabel}
+      </span>
+      <div className="relative flex flex-col items-center gap-2">
+        <img
+          src={speaker.photoUrl}
+          alt={speaker.name}
+          className="w-24 h-24 rounded-full border-4 border-white shadow-lg -mt-12 object-cover"
+        />
+        <h2 className="text-xl font-bold text-white">{speaker.name}</h2>
+        <h3 className="text-base font-semibold text-white">{talk.title}</h3>
+        <p className="text-sm text-white/90">{talk.eventName}</p>
+        {talk.status === 'upcoming' && talk.date && (
+          <p className="text-sm text-white/90">{talk.date}</p>
+        )}
+        {link && (
+          <button
+            onClick={openLink}
+            className="mt-2 bg-pink-500 hover:bg-pink-600 text-white rounded-full px-4 py-2 font-semibold"
+          >
+            {buttonLabel}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SpeakerCard;

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import SpeakerCard from '../components/SpeakerCard';
+
+const Examples = () => {
+  const upcoming = {
+    speaker: {
+      name: 'Анна Каренина',
+      photoUrl: 'https://via.placeholder.com/150',
+    },
+    talk: {
+      title: 'Будущие тренды фронтенда',
+      description: 'О новинках',
+      eventName: 'Frontend Conf',
+      status: 'upcoming' as const,
+      date: '2025-05-20',
+      registrationLink: 'https://example.com/reg',
+    },
+  };
+
+  const past = {
+    speaker: {
+      name: 'Лев Толстой',
+      photoUrl: 'https://via.placeholder.com/150',
+    },
+    talk: {
+      title: 'История JavaScript',
+      description: 'От начала до наших дней',
+      eventName: 'JS Meetup',
+      status: 'past' as const,
+      recordingLink: 'https://example.com/video',
+    },
+  };
+
+  return (
+    <div className="p-4 flex flex-col gap-6 items-center">
+      <SpeakerCard
+        speaker={upcoming.speaker}
+        talk={upcoming.talk}
+        gradient="from-yellow-300 via-pink-400 to-pink-600"
+      />
+      <SpeakerCard
+        speaker={past.speaker}
+        talk={past.talk}
+        gradient="from-green-300 via-blue-400 to-purple-500"
+      />
+    </div>
+  );
+};
+
+export default Examples;


### PR DESCRIPTION
## Summary
- create decorative `SpeakerCard` React component
- add sample pattern graphic
- show usage examples with past and upcoming talks

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fef38dfa88328b17992a7e6d773c3