### PR TITLE
Fix image uploads for speakers

### DIFF
--- a/src/pages/api/speakers/[id].ts
+++ b/src/pages/api/speakers/[id].ts
@@ -17,3 +17,11 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
   res.status(405).end();
 }
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '4mb',
+    },
+  },
+};

--- a/src/pages/api/speakers/index.ts
+++ b/src/pages/api/speakers/index.ts
@@ -17,3 +17,11 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
   res.status(405).end();
 }
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '4mb',
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- allow larger payloads on speaker API routes so big image files don't cause errors

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c495c82c8328ae0af523eb4e70c4