### PR TITLE
Add bottom navigation menu

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { getUsername } from '../utils/telegram';
+
+const allowedUsers = (process.env.ADMIN_USERNAMES || '').split(',');
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const Layout: React.FC<Props> = ({ children }) => {
+  const router = useRouter();
+  const [isAdmin, setIsAdmin] = useState(false);
+
+  useEffect(() => {
+    const username = getUsername();
+    if (username && allowedUsers.includes(username)) {
+      setIsAdmin(true);
+    }
+  }, []);
+
+  const linkClass = (path: string) =>
+    `p-2 ${router.pathname === path ? 'text-blue-600' : 'text-gray-600'}`;
+
+  return (
+    <div className="pb-20">
+      {children}
+      <nav className="fixed bottom-0 left-0 right-0 flex justify-around border-t bg-white">
+        <Link href="/" className={linkClass('/')}
+          aria-label="Выступления">
+          <span className="text-2xl">🎤</span>
+        </Link>
+        {isAdmin && (
+          <Link href="/admin" className={linkClass('/admin')}
+            aria-label="Админка">
+            <span className="text-2xl">🛠</span>
+          </Link>
+        )}
+        <Link href="/profile" className={linkClass('/profile')} aria-label="Личный кабинет">
+          <span className="text-2xl">👤</span>
+        </Link>
+      </nav>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,11 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
+import Layout from '../components/Layout';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
 }

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,0 +1,12 @@
+import React, { useEffect } from 'react';
+import { expand } from '../utils/telegram';
+
+const ProfilePage: React.FC = () => {
+  useEffect(() => {
+    expand();
+  }, []);
+
+  return <p className="p-4">Личный кабинет</p>;
+};
+
+export default ProfilePage;


### PR DESCRIPTION
## Summary
- add Layout component with icon-based navigation
- show admin link only for allowed users
- add profile page placeholder
- wrap pages with Layout for persistent bottom menu

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d79a496883289c82606ffd1d10eb