### PR TITLE
Fix Telegram errors in frontend

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -7,6 +7,8 @@
   <link rel="stylesheet" href="styles.css" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <!-- Telegram WebApp JS -->
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
 <body>
   <div id="admin-root"></div>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -129,6 +129,7 @@ function App() {
   );
 }
 
-Telegram?.WebApp?.expand();
+// Expand the Telegram WebApp if running inside Telegram
+window.Telegram?.WebApp?.expand();
 
 ReactDOM.createRoot(document.getElementById('root')).render(e(App));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,8 @@
   <!-- React and dependencies from CDN -->
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <!-- Telegram WebApp JS to access Telegram features -->
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
## Summary
- include Telegram WebApp script in HTML pages
- safely call `Telegram.WebApp.expand()` via `window` object

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68657ceac38883289dba23f3f0fd0c4f