### PR TITLE
Update talk form logic

### DIFF
--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -1,3 +1,5 @@
+import { DIRECTIONS } from './directions.js';
+
 const e = React.createElement;
 const { useState, useEffect } = React;
 
@@ -69,7 +71,9 @@ function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
     ),
     e('div', null,
       e('label', null, 'Направление'),
-      e('input', { value: direction, onChange: ev => setDirection(ev.target.value) })
+      e('select', { value: direction, onChange: ev => setDirection(ev.target.value) },
+        DIRECTIONS.map(d => e('option', { key: d, value: d }, d))
+      )
     ),
     e('div', null,
       e('label', null, 'Статус'),
@@ -82,11 +86,11 @@ function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
       e('label', null, 'Дата'),
       e('input', { type: 'date', value: date, onChange: ev => setDate(ev.target.value) })
     ),
-    e('div', null,
+    status === 'upcoming' && e('div', null,
       e('label', null, 'Ссылка регистрации'),
       e('input', { value: registrationLink, onChange: ev => setRegistrationLink(ev.target.value) })
     ),
-    e('div', null,
+    status === 'past' && e('div', null,
       e('label', null, 'Ссылка записи'),
       e('input', { value: recordingLink, onChange: ev => setRecordingLink(ev.target.value) })
     ),

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,3 +1,5 @@
+import { DIRECTIONS } from './directions.js';
+
 const e = React.createElement;
 const { useState, useEffect } = React;
 
@@ -119,7 +121,7 @@ function App() {
       { className: 'filters' },
       e('select', { value: direction, onChange: e => setDirection(e.target.value) },
         e('option', { value: 'all' }, 'Все направления'),
-        ['frontend','backend','QA','mobile','product','data','manager'].map(d =>
+        DIRECTIONS.map(d =>
           e('option', { key: d, value: d }, d)
         )
       ),

--- a/frontend/directions.js
+++ b/frontend/directions.js
@@ -1,0 +1,1 @@
+export const DIRECTIONS = ['frontend','backend','QA','mobile','product','data','manager'];


### PR DESCRIPTION
## Summary
- share list of directions between the main page and admin
- use select for direction in admin form
- show registration link only for upcoming talks
- show recording link only for past talks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686588c9a6008328b45b7d3b7aeb2605