### PR TITLE
Add bottom navigation and profile page

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,6 +127,11 @@ def admin_page():
     return send_from_directory('frontend', 'admin.html')
 
 
+@app.route('/profile')
+def profile_page():
+    return send_from_directory('frontend', 'profile.html')
+
+
 @app.route('/<path:path>')
 def static_proxy(path):
     return send_from_directory('frontend', path)

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -12,6 +12,11 @@
 </head>
 <body>
   <div id="admin-root"></div>
+  <nav class="bottom-nav">
+    <a href="/" title="Выступления">🎤</a>
+    <a href="/admin" class="active" title="Админка">⚙️</a>
+    <a href="/profile" title="Личный кабинет">👤</a>
+  </nav>
   <script type="module" src="admin.js"></script>
 </body>
 </html>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -3,21 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Speakers Platform</title>
+  <title>Profile</title>
   <link rel="stylesheet" href="styles.css" />
-  <!-- React and dependencies from CDN -->
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <!-- Telegram WebApp JS to access Telegram features -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
 <body>
-  <div id="root"></div>
+  <div id="profile-root"></div>
   <nav class="bottom-nav">
-    <a href="/" class="active" title="Выступления">🎤</a>
+    <a href="/" title="Выступления">🎤</a>
     <a href="/admin" title="Админка">⚙️</a>
-    <a href="/profile" title="Личный кабинет">👤</a>
+    <a href="/profile" class="active" title="Личный кабинет">👤</a>
   </nav>
-  <script type="module" src="app.js"></script>
+  <script type="module" src="profile.js"></script>
 </body>
 </html>

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -1,0 +1,23 @@
+const e = React.createElement;
+const { useEffect, useState } = React;
+
+function ProfileApp() {
+  const [user, setUser] = useState(null);
+  useEffect(() => {
+    const tg = window.Telegram?.WebApp;
+    setUser(tg?.initDataUnsafe?.user || null);
+    tg?.expand();
+  }, []);
+
+  if (!user) {
+    return e('div', null, 'Информация о пользователе недоступна');
+  }
+
+  return e('div', null,
+    e('h2', null, 'Личный кабинет'),
+    e('div', null, `Имя: ${user.first_name} ${user.last_name || ''}`),
+    e('div', null, `Username: @${user.username || ''}`)
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('profile-root')).render(e(ProfileApp));

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -7,6 +7,7 @@ body {
 
 #root {
   padding: 10px;
+  padding-bottom: 70px; /* space for bottom nav */
 }
 
 .card {
@@ -55,4 +56,26 @@ form select {
   padding: 6px;
   border-radius: 4px;
   border: 1px solid #ccc;
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  background: #fff;
+  border-top: 1px solid #ccc;
+  padding: 10px 0;
+}
+
+.bottom-nav a {
+  text-decoration: none;
+  font-size: 24px;
+  color: #666;
+}
+
+.bottom-nav a.active {
+  color: #03a9f4;
 }


### PR DESCRIPTION
## Summary
- add bottom nav with icons on main and admin pages
- create new profile page with simple user info
- style bottom nav and adjust padding
- expose `/profile` route in the backend

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686593ca44188328b3aeb78ea93c8afa