### PR TITLE
Store data in /data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ out
 .env
 
 db.json
-frontend/photos/*
+data/
 amvera.yml

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project contains a tiny Flask backend and a static front‑end written in React. It showcases speakers and their talks inside a Telegram WebApp.
 
-Data is stored in `db.json` by default (path can be changed with the `DB_PATH` environment variable).
+Data is stored in `/data/db.json` by default (the location can be changed via the `DB_PATH` environment variable).
 
 ## Running locally
 

--- a/app.py
+++ b/app.py
@@ -7,10 +7,10 @@ import datetime
 app = Flask(__name__)
 
 # Where uploaded photos will be stored
-UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'frontend', 'photos')
+UPLOAD_FOLDER = os.getenv('UPLOAD_FOLDER', '/data/photos')
 os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
-DB_PATH = os.getenv('DB_PATH', os.path.join(os.path.dirname(__file__), '../db.json'))
+DB_PATH = os.getenv('DB_PATH', '/data/db.json')
 
 
 def read_db():
@@ -116,6 +116,11 @@ def upload():
     os.makedirs(UPLOAD_FOLDER, exist_ok=True)
     file.save(os.path.join(UPLOAD_FOLDER, filename))
     return jsonify({'url': f'/photos/{filename}'})
+
+
+@app.route('/photos/<path:filename>')
+def serve_photo(filename):
+    return send_from_directory(UPLOAD_FOLDER, filename)
 
 @app.route('/')
 def index():


### PR DESCRIPTION
## Summary
- store uploaded photos and DB file in `/data`
- add route to serve uploaded photos
- update README with new location for saved data
- ignore the `data/` folder

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68659521ae7c8328a595f78e4bd86f3b