### PR TITLE
Restrict admin section to ADMIN_USERNAMES

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,10 @@ os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 
 DB_PATH = os.getenv('DB_PATH', '/data/db.json')
 
+# Comma separated list of Telegram usernames allowed in the admin section
+ADMIN_USERNAMES = [u.strip() for u in os.getenv('ADMIN_USERNAMES', '')
+                   .split(',') if u.strip()]
+
 
 def read_db():
     if not os.path.exists(DB_PATH):
@@ -141,6 +145,12 @@ def upload():
         f.write(buf.getvalue())
 
     return jsonify({'url': f'/photos/{filename}'})
+
+
+@app.route('/api/admin-users')
+def admin_users():
+    """Return the list of usernames allowed to access the admin interface."""
+    return jsonify(ADMIN_USERNAMES)
 
 
 @app.route('/photos/<path:filename>')

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -14,9 +14,10 @@
   <div id="admin-root"></div>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
-    <a href="/admin" class="active" title="Админка">⚙️</a>
+    <a href="/admin" class="admin-link active" title="Админка">⚙️</a>
     <a href="/profile" title="Личный кабинет">👤</a>
   </nav>
+  <script type="module" src="permissions.js" defer></script>
   <script type="module" src="admin.js"></script>
 </body>
 </html>

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -3,7 +3,6 @@ import { DIRECTIONS } from './directions.js';
 const e = React.createElement;
 const { useState, useEffect } = React;
 
-const ALLOWED_USERS = ['admin'];
 
 function SpeakerForm({ initial = {}, onSubmit, onCancel }) {
   const [name, setName] = useState(initial.name || '');
@@ -130,11 +129,17 @@ function AdminApp() {
   useEffect(() => {
     const tg = window.Telegram?.WebApp;
     const user = tg?.initDataUnsafe?.user;
-    if (user) {
-      setUsername(user.username);
-      setAuthorized(ALLOWED_USERS.includes(user.username));
-    }
     tg?.expand();
+
+    fetch('/api/admin-users')
+      .then(r => r.json())
+      .then(list => {
+        if (user) {
+          setUsername(user.username);
+          setAuthorized(list.includes(user.username));
+        }
+      });
+
     fetch('/api/speakers').then(r => r.json()).then(setSpeakers);
     fetch('/api/talks').then(r => r.json()).then(setTalks);
   }, []);
@@ -175,9 +180,9 @@ function AdminApp() {
     setTalks(talks.filter(t => t.id !== id));
   };
 
-  // if (!authorized) {
-  //   return e('div', null, 'Доступ запрещен для ', username || 'guest');
-  // }
+  if (!authorized) {
+    return e('div', null, 'Доступ запрещен для ', username || 'guest');
+  }
 
   const speakerSection = editingSpeaker ?
     e(SpeakerForm, { initial: editingSpeaker, onSubmit: saveSpeaker, onCancel: () => setEditingSpeaker(null) }) :

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,9 +15,10 @@
   <div id="root"></div>
   <nav class="bottom-nav">
     <a href="/" class="active" title="Выступления">🎤</a>
-    <a href="/admin" title="Админка">⚙️</a>
+    <a href="/admin" class="admin-link" title="Админка">⚙️</a>
     <a href="/profile" title="Личный кабинет">👤</a>
   </nav>
+  <script type="module" src="permissions.js" defer></script>
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/frontend/permissions.js
+++ b/frontend/permissions.js
@@ -1,0 +1,16 @@
+export async function hideAdminLinks() {
+  const tg = window.Telegram?.WebApp;
+  const username = tg?.initDataUnsafe?.user?.username;
+  let allowed = [];
+  try {
+    const res = await fetch('/api/admin-users');
+    allowed = await res.json();
+  } catch (e) {
+    // ignore
+  }
+  if (!username || !allowed.includes(username)) {
+    document.querySelectorAll('.admin-link').forEach(el => el.remove());
+  }
+}
+
+hideAdminLinks();

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -13,9 +13,10 @@
   <div id="profile-root"></div>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
-    <a href="/admin" title="Админка">⚙️</a>
+    <a href="/admin" class="admin-link" title="Админка">⚙️</a>
     <a href="/profile" class="active" title="Личный кабинет">👤</a>
   </nav>
+  <script type="module" src="permissions.js" defer></script>
   <script type="module" src="profile.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add ADMIN_USERNAMES env variable support
- expose `/api/admin-users` endpoint
- hide admin links when user is not allowed
- check admin access in `admin.js`

## Testing
- `python -m py_compile app.py && node --check frontend/admin.js && node --check frontend/permissions.js && node --check frontend/app.js && node --check frontend/profile.js`

------
https://chatgpt.com/codex/tasks/task_e_68663715559c832883ac369caa89a914