### PR TITLE
Improve admin panel layout

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -1,0 +1,53 @@
+/* Styles specific to the admin interface */
+
+.admin-page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.admin-page header {
+  background: #03a9f4;
+  color: #fff;
+  padding: 16px;
+  text-align: center;
+}
+
+.admin-content {
+  flex: 1;
+  padding: 10px;
+  padding-bottom: 70px; /* space for bottom nav */
+}
+
+.admin-tabs {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.admin-tabs button {
+  flex: 1;
+}
+
+.admin-list > div {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #fff;
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.admin-form label {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.admin-form input,
+.admin-form textarea,
+.admin-form select {
+  width: 100%;
+}
+

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,13 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Admin</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="admin.css" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <!-- Telegram WebApp JS -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
-<body>
-  <div id="admin-root"></div>
+<body class="admin-page">
+  <header>
+    <h1>Панель администратора</h1>
+  </header>
+  <main id="admin-root" class="admin-content"></main>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
     <a href="/admin" class="active" title="Админка">⚙️</a>

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -21,7 +21,7 @@ function SpeakerForm({ initial = {}, onSubmit, onCancel }) {
     setUploading(false);
   };
 
-  return e('form', { onSubmit: ev => { ev.preventDefault(); onSubmit({ ...initial, name, description, photoUrl }); } },
+  return e('form', { className: 'admin-form', onSubmit: ev => { ev.preventDefault(); onSubmit({ ...initial, name, description, photoUrl }); } },
     e('div', null,
       e('label', null, 'Имя'),
       e('input', { value: name, onChange: ev => setName(ev.target.value) })
@@ -75,7 +75,7 @@ function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
     });
   };
 
-  return e('form', { onSubmit: handleSubmit },
+  return e('form', { className: 'admin-form', onSubmit: handleSubmit },
     e('div', null,
       e('label', null, 'Спикер'),
       e('select', { value: speakerId, onChange: ev => setSpeakerId(ev.target.value), required: true },
@@ -181,7 +181,7 @@ function AdminApp() {
 
   const speakerSection = editingSpeaker ?
     e(SpeakerForm, { initial: editingSpeaker, onSubmit: saveSpeaker, onCancel: () => setEditingSpeaker(null) }) :
-    e('div', null,
+    e('div', { className: 'admin-list' },
       e('button', { onClick: () => setEditingSpeaker({}) }, 'Добавить спикера'),
       speakers.map(s => e('div', { key: s.id },
         e('span', null, s.name),
@@ -194,7 +194,7 @@ function AdminApp() {
 
   const talkSection = editingTalk ?
     e(TalkForm, { initial: editingTalk, speakers, onSubmit: saveTalk, onCancel: () => setEditingTalk(null) }) :
-    e('div', null,
+    e('div', { className: 'admin-list' },
       e('button', { onClick: () => setEditingTalk({}) }, 'Добавить выступление'),
       talks.map(t => e('div', { key: t.id },
         e('span', null, t.title),
@@ -206,7 +206,7 @@ function AdminApp() {
     );
 
   return e('div', null,
-    e('div', null,
+    e('div', { className: 'admin-tabs' },
       e('button', { onClick: () => setTab('speakers') }, 'Спикеры'),
       e('button', { onClick: () => setTab('talks') }, 'Выступления')
     ),


### PR DESCRIPTION
## Summary
- add dedicated stylesheet for admin interface
- give admin page a header and wrapper structure
- style admin tabs, lists, and forms

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686678d855688328bdfd4cf58b92cedb