### PR TITLE
Add gamified look with swiper

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,7 +45,7 @@ def speakers():
         return jsonify(data['speakers'])
 
     body = request.get_json() or {}
-    body.setdefault('photoUrl', '/default_icon.png')
+    body.setdefault('photoUrl', '/default_icon.svg')
     new_speaker = {'id': str(uuid4()), **body}
     data['speakers'].append(new_speaker)
     write_db(data)
@@ -67,7 +67,7 @@ def speaker_by_id(id):
 
     body = request.get_json() or {}
     if 'photoUrl' not in body:
-        body['photoUrl'] = '/default_icon.png'
+        body['photoUrl'] = '/default_icon.svg'
     speakers[idx].update(body)
     write_db(data)
     return jsonify(speakers[idx])

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -4,8 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Admin</title>
+  <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
   <link rel="stylesheet" href="styles.css" />
   <link rel="stylesheet" href="admin.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <!-- Telegram WebApp JS -->

--- a/frontend/default_icon.svg
+++ b/frontend/default_icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="200" height="200">
+  <rect width="200" height="200" rx="20" fill="#444" />
+  <circle cx="100" cy="70" r="40" fill="#888" stroke="#0ff" stroke-width="6"/>
+  <rect x="60" y="120" width="80" height="60" fill="#888" stroke="#0ff" stroke-width="6"/>
+</svg>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,12 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Speakers Platform</title>
+  <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
   <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <!-- React and dependencies from CDN -->
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <!-- Telegram WebApp JS to access Telegram features -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
 </head>
 <body>
   <div id="root"></div>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Profile</title>
   <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://telegram.org/js/telegram-web-app.js"></script>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,8 +1,10 @@
 body {
-  font-family: sans-serif;
+  font-family: 'Inter', sans-serif;
   margin: 0;
   padding: 0;
-  background: #f0f0f0;
+  background: linear-gradient(135deg, #ff00cc, #3333ff);
+  min-height: 100vh;
+  color: #fff;
 }
 
 #root {
@@ -11,27 +13,54 @@ body {
 }
 
 .card {
-  background: white;
-  border-radius: 12px;
+  background: rgba(255,255,255,0.1);
+  border-radius: 16px;
   padding: 20px;
-  margin-bottom: 20px;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  margin-bottom: 10px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  backdrop-filter: blur(10px);
+  transition: transform 0.3s, opacity 0.3s;
+  opacity: 0;
+  transform: scale(0.9);
+  animation: fadeInScale 0.5s forwards;
 }
 
 .card img {
   max-width: 100%;
   border-radius: 12px;
+  object-fit: cover;
 }
 
 .card-title {
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   margin: 10px 0;
+  font-weight: 600;
 }
 
 .filters {
   margin-bottom: 20px;
-  display: flex;
+  display: none;
+  flex-direction: column;
   gap: 10px;
+  margin-top: 10px;
+}
+.filters.show {
+  display: flex;
+}
+
+.swiper-container {
+  width: 100%;
+  padding-top: 20px;
+  padding-bottom: 40px;
+}
+
+.swiper-slide {
+  width: 70%;
+  max-width: 260px;
+}
+
+.swiper-slide-active {
+  transform: scale(1.1);
 }
 
 button {
@@ -39,8 +68,10 @@ button {
   border: none;
   border-radius: 8px;
   cursor: pointer;
-  background: #03a9f4;
-  color: white;
+  background: #00e5ff;
+  color: #000;
+  font-weight: 600;
+  box-shadow: 0 0 10px rgba(0,229,255,0.7);
 }
 
 form {
@@ -65,22 +96,34 @@ form select {
   right: 0;
   display: flex;
   justify-content: space-around;
-  background: #fff;
-  border-top: 1px solid #ccc;
+  background: rgba(0,0,0,0.6);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid rgba(255,255,255,0.3);
   padding: 10px 0;
 }
 
 .bottom-nav a {
   text-decoration: none;
   font-size: 24px;
-  color: #666;
+  color: #fff;
 }
 
 .bottom-nav a.active {
-  color: #03a9f4;
+  color: #00e5ff;
 }
 
 .error {
   color: red;
   margin-bottom: 10px;
+}
+
+@keyframes fadeInScale {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }


### PR DESCRIPTION
## Summary
- add default placeholder icon
- refresh CSS with neon style and gradient background
- integrate Swiper slider and font imports in HTML
- replace vertical list with horizontal swiper in React app
- small UI fixes for admin and profile pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866926f59f88328ac3e9f1e4563b6be