### PR TITLE
Add BottomSheet panel with swiper integration

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,7 @@
 </head>
 <body>
   <div id="root"></div>
+  <div id="bottom-sheet-root"></div>
   <nav class="bottom-nav">
     <a href="/" class="active" title="Выступления">🎤</a>
     <a href="/admin" title="Админка">⚙️</a>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -9,7 +9,7 @@ body {
 
 #root {
   padding: 10px;
-  padding-bottom: 70px; /* space for bottom nav */
+  padding-bottom: 150px; /* space for bottom nav and bottom sheet */
 }
 
 .card {
@@ -87,6 +87,18 @@ form select {
   padding: 6px;
   border-radius: 4px;
   border: 1px solid #ccc;
+}
+
+.bottom-sheet {
+  position: fixed;
+  bottom: 70px;
+  left: 0;
+  right: 0;
+  background: rgba(0,0,0,0.8);
+  backdrop-filter: blur(10px);
+  padding: 15px;
+  border-top-left-radius: 16px;
+  border-top-right-radius: 16px;
 }
 
 .bottom-nav {


### PR DESCRIPTION
## Summary
- create `BottomSheet` component
- update `Card` to show only speaker photo
- track active slide and render bottom sheet with current talk
- adjust page layout and styles for fixed bottom sheet
- update index to include new bottom sheet root

## Testing
- `python -m py_compile app.py && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_6866a8d703e88328b3b579df42726e5f