### PR TITLE
Remove card borders and color bottom sheet

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,5 +1,15 @@
 import { DIRECTIONS } from './directions.js';
 
+const ACCENTS = {
+  frontend: '#4caf50',
+  backend: '#795548',
+  QA: '#9c27b0',
+  mobile: '#ff9800',
+  product: '#f44336',
+  data: '#2196f3',
+  manager: '#607d8b',
+};
+
 const e = React.createElement;
 const { useState, useEffect, useRef } = React;
 
@@ -41,19 +51,9 @@ const TEST_TALKS = [
 ];
 
 function Card({ talk, speaker }) {
-  const accent = {
-    frontend: '#4caf50',
-    backend: '#795548',
-    QA: '#9c27b0',
-    mobile: '#ff9800',
-    product: '#f44336',
-    data: '#2196f3',
-    manager: '#607d8b',
-  }[talk.direction] || '#03a9f4';
-
   return e(
     'div',
-    { className: 'card', style: { borderLeft: `8px solid ${accent}` } },
+    { className: 'card' },
     e('img', { src: speaker.photoUrl || '/default_icon.svg', alt: speaker.name })
   );
 }
@@ -63,6 +63,8 @@ function BottomSheet({ talk, speaker }) {
     return e('div', { className: 'bottom-sheet' }, 'Нет данных');
   }
 
+  const accent = ACCENTS[talk.direction] || '#03a9f4';
+
   const link =
     talk.status === 'past'
       ? e('a', { href: talk.recordingLink, target: '_blank' }, 'Запись')
@@ -70,7 +72,7 @@ function BottomSheet({ talk, speaker }) {
 
   return e(
     'div',
-    { className: 'bottom-sheet' },
+    { className: 'bottom-sheet', style: { borderLeft: `8px solid ${accent}` } },
     e('h3', null, talk.title),
     e('div', { className: 'sheet-speaker' }, speaker?.name || ''),
     e('div', null, talk.description),

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -13,12 +13,8 @@ body {
 }
 
 .card {
-  background: rgba(255,255,255,0.1);
-  border-radius: 16px;
-  padding: 20px;
+  padding: 0;
   margin-bottom: 10px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
-  backdrop-filter: blur(10px);
   transition: transform 0.3s, opacity 0.3s;
   opacity: 0;
   transform: scale(0.9);


### PR DESCRIPTION
## Summary
- remove decorative frame around speaker photo
- show direction accent on the description sheet instead of the card

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6866d1b28a0c832897a4fe3baf01bf6f