### PR TITLE
Improve main screen swipe effect and info sheet

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -75,7 +75,7 @@ function BottomSheet({ talk, speaker }) {
     e('h3', null, talk.title),
     e('div', { className: 'sheet-speaker' }, speaker?.name || ''),
     e('div', null, talk.description),
-    e('div', null, talk.eventName),
+    e('div', { className: 'sheet-event' }, talk.eventName),
     link
   );
 }
@@ -132,15 +132,15 @@ function App() {
       if (swiperRef.current.swiper) swiperRef.current.swiper.destroy();
       swiperRef.current.swiper = new window.Swiper(swiperRef.current, {
         centeredSlides: true,
-        slidesPerView: 3,
+        slidesPerView: 'auto',
         spaceBetween: 20,
         loop: false,
         effect: 'coverflow',
         coverflowEffect: {
           rotate: 0,
           stretch: 0,
-          depth: 100,
-          modifier: 2.5,
+          depth: 120,
+          modifier: 2,
           slideShadows: false,
         },
         on: {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -53,16 +53,18 @@ body {
 }
 
 .swiper-slide {
-  transition: transform 0.3s;
+  transition: transform 0.3s, filter 0.3s;
 }
 
 .swiper-slide-prev,
 .swiper-slide-next {
-  transform: scale(0.85);
+  transform: translateY(20px) scale(0.85);
+  filter: brightness(0.7);
+  z-index: 1;
 }
 
 .swiper-slide-active {
-  transform: scale(1.1);
+  transform: translateY(-20px) scale(1.2);
   z-index: 2;
 }
 
@@ -105,7 +107,7 @@ form select {
 
 .bottom-sheet {
   position: fixed;
-  bottom: 0;
+  bottom: 60px;
   left: 0;
   right: 0;
   background: #111;
@@ -123,6 +125,24 @@ form select {
   background: #555;
   border-radius: 2px;
   margin: 0 auto 12px;
+}
+
+.bottom-sheet h3 {
+  margin: 0 0 8px 0;
+  font-weight: 700;
+  color: #fff;
+}
+
+.bottom-sheet .sheet-speaker,
+.bottom-sheet .sheet-event {
+  margin-top: 4px;
+}
+
+.bottom-sheet a {
+  color: #1ec4ff;
+  text-decoration: underline;
+  display: inline-block;
+  margin-top: 8px;
 }
 
 .bottom-nav {


### PR DESCRIPTION
## Summary
- adjust Swiper settings and bottom sheet markup
- tweak slide animations to enlarge the active card
- style bottom sheet elements and lift active slide

## Testing
- `python -m py_compile app.py`
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6867a529e38c83288b3e15ea940deae6