### PR TITLE
Improve speaker card layout

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,3 +1,8 @@
+:root {
+  --speaker-top: 60px;
+  --speaker-height: 33vh;
+}
+
 body {
   font-family: 'Inter', sans-serif;
   margin: 0;
@@ -15,6 +20,7 @@ body {
 }
 
 .card {
+  position: relative;
   padding: 0;
   margin-bottom: 10px;
   transition: transform 0.3s, opacity 0.3s;
@@ -24,8 +30,9 @@ body {
 }
 
 .card img {
-  max-width: 100%;
-  max-height: 180px;
+  width: auto;
+  max-width: none;
+  height: 200px;
   border-radius: 12px;
   object-fit: cover;
 }
@@ -54,19 +61,47 @@ body {
 }
 
 .swiper-slide {
+  overflow: visible;
   transition: transform 0.3s, filter 0.3s;
 }
 
 .swiper-slide-prev,
 .swiper-slide-next {
   transform: translateY(20px) scale(0.85);
-  filter: brightness(0.7);
+  opacity: 0.7;
   z-index: 1;
 }
 
 .swiper-slide-active {
   transform: translateY(-20px) scale(1.2);
   z-index: 2;
+}
+
+.swiper-slide-active .card img {
+  position: absolute;
+  top: var(--speaker-top);
+  left: 50%;
+  transform: translateX(-50%);
+  height: var(--speaker-height);
+  z-index: 2;
+}
+
+.swiper-slide-prev .card img,
+.swiper-slide-next .card img {
+  position: absolute;
+  top: var(--speaker-top);
+  height: calc(var(--speaker-height) * 0.7);
+  z-index: 1;
+}
+
+.swiper-slide-prev .card img {
+  left: 5%;
+  opacity: 0.7;
+}
+
+.swiper-slide-next .card img {
+  right: 5%;
+  opacity: 0.7;
 }
 
 button {
@@ -108,17 +143,16 @@ form select {
 
 .bottom-sheet {
   position: fixed;
-  bottom: 50px;
+  top: calc(var(--speaker-top) + var(--speaker-height));
+  bottom: 60px;
   left: 0;
   right: 0;
   background: #111;
   color: #fff;
-  padding: 0 20px 20px;
-  border-top-left-radius: 16px;
-  border-top-right-radius: 16px;
-  min-height: 50vh;
-  max-height: 70vh;
+  padding: 20px;
+  border-radius: 20px 20px 0 0;
   overflow-y: auto;
+  min-height: 40vh;
 }
 
 .bottom-sheet .handle {


### PR DESCRIPTION
## Summary
- restyle cards to emphasise the active speaker
- ensure adjacent speakers fade into the background
- align bottom sheet with the enlarged speaker

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6867d6e78a088328864a8970d7f462fc