### PR TITLE
Improve speaker layout and bottom sheet

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,6 +1,6 @@
 :root {
-  --speaker-top: 60px;
-  --speaker-height: 33vh;
+  --speaker-top: 40px;
+  --speaker-height: 45vh;
 }
 
 body {
@@ -73,7 +73,7 @@ body {
 }
 
 .swiper-slide-active {
-  transform: translateY(-20px) scale(1.2);
+  transform: translateY(-20px) scale(1.3);
   z-index: 2;
 }
 
@@ -95,12 +95,12 @@ body {
 }
 
 .swiper-slide-prev .card img {
-  left: 5%;
+  left: -10%;
   opacity: 0.7;
 }
 
 .swiper-slide-next .card img {
-  right: 5%;
+  right: -10%;
   opacity: 0.7;
 }
 
@@ -116,9 +116,9 @@ button {
 }
 
 .filter-btn {
-  position: fixed;
-  top: 10px;
-  left: 10px;
+  position: absolute;
+  top: 16px;
+  left: 16px;
   z-index: 10;
   background: #00ffff;
   color: #000;
@@ -143,14 +143,14 @@ form select {
 
 .bottom-sheet {
   position: fixed;
-  top: calc(var(--speaker-top) + var(--speaker-height));
+  top: calc(var(--speaker-top) + var(--speaker-height) * 0.7);
   bottom: 60px;
   left: 0;
   right: 0;
   background: #111;
   color: #fff;
-  padding: 20px;
-  border-radius: 20px 20px 0 0;
+  padding: 20px 24px;
+  border-radius: 0 0 20px 20px;
   overflow-y: auto;
   min-height: 40vh;
 }
@@ -158,7 +158,7 @@ form select {
 .bottom-sheet .handle {
   width: 40px;
   height: 4px;
-  background: #555;
+  background: #666;
   border-radius: 2px;
   margin: 0 auto 8px;
 }
@@ -167,6 +167,7 @@ form select {
   margin: 0 0 8px 0;
   font-weight: 700;
   color: #fff;
+  font-size: 22px;
 }
 
 .bottom-sheet .sheet-speaker,
@@ -175,7 +176,7 @@ form select {
 }
 
 .bottom-sheet a {
-  color: #1ec4ff;
+  color: #3ea6ff;
   text-decoration: underline;
   display: inline-block;
   margin-top: 8px;


### PR DESCRIPTION
## Summary
- enlarge center speaker and move up
- offset side speakers outwards
- overlap bottom sheet under photo and style handle
- tidy filter button placement and link color

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6867da184cb08328af157f1feeea4726