### PR TITLE
Improve speaker card layout

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,6 +1,6 @@
 :root {
   --speaker-top: 40px;
-  --speaker-height: 45vh;
+  --speaker-height: 55vh;
 }
 
 body {
@@ -96,12 +96,12 @@ body {
 
 .swiper-slide-prev .card img {
   left: -10%;
-  opacity: 0.7;
+  opacity: 0.8;
 }
 
 .swiper-slide-next .card img {
   right: -10%;
-  opacity: 0.7;
+  opacity: 0.8;
 }
 
 button {
@@ -143,14 +143,14 @@ form select {
 
 .bottom-sheet {
   position: fixed;
-  top: calc(var(--speaker-top) + var(--speaker-height) * 0.7);
+  top: calc(var(--speaker-top) + var(--speaker-height));
   bottom: 60px;
   left: 0;
   right: 0;
   background: #111;
   color: #fff;
-  padding: 20px 24px;
-  border-radius: 0 0 20px 20px;
+  padding: 24px;
+  border-radius: 20px 20px 0 0;
   overflow-y: auto;
   min-height: 40vh;
 }
@@ -158,7 +158,7 @@ form select {
 .bottom-sheet .handle {
   width: 40px;
   height: 4px;
-  background: #666;
+  background: #aaa;
   border-radius: 2px;
   margin: 0 auto 8px;
 }


### PR DESCRIPTION
## Summary
- resize central speaker area
- sync sheet position and style
- tweak side speaker opacity and colours

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6867e536cec4832881d28384310beeef