### PR TITLE
Adjust speaker card spacing

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,6 +1,8 @@
 :root {
-  --speaker-top: 40px;
-  --speaker-height: 55vh;
+  /* Lift speaker images higher on the screen */
+  --speaker-top: 20px;
+  /* Slightly reduce the height so prev/next speakers remain visible */
+  --speaker-height: 50vh;
 }
 
 body {
@@ -67,7 +69,8 @@ body {
 
 .swiper-slide-prev,
 .swiper-slide-next {
-  transform: translateY(20px) scale(0.85);
+  /* keep neighbour slides visible above the sheet */
+  transform: translateY(0) scale(0.85);
   opacity: 0.7;
   z-index: 1;
 }


### PR DESCRIPTION
## Summary
- raise speaker cards by reducing `--speaker-top`
- shrink card height so neighbor slides stay visible
- prevent vertical offset on prev/next slides

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6867ef2dc9a48328b2c9f508c7e01d70