### PR TITLE
Add Telegram bot with welcome message and mini app menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,22 @@ python app.py
 ```
 
 Open `http://localhost:5000/` to see the demo cards. Visit `/admin` for the admin placeholder.
+
+## Telegram bot
+
+The repository also includes a simple Telegram bot in `bot.py`. The bot sends a
+welcome message describing the mini app and adds a `MiniApp` button in the bot
+menu that opens the web application.
+
+Set the following environment variables before running:
+
+```
+BOT_TOKEN=<telegram bot token>
+WEBAPP_URL=<url where the mini app is hosted>
+```
+
+Then start the bot with:
+
+```bash
+python bot.py
+```

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,33 @@
+import os
+import asyncio
+from telegram import Update, WebAppInfo, MenuButtonWebApp
+from telegram.ext import Application, CommandHandler, ContextTypes
+
+TOKEN = os.getenv("BOT_TOKEN")
+WEBAPP_URL = os.getenv("WEBAPP_URL", "https://example.com")
+
+WELCOME_TEXT = (
+    "Привет! Это бот Speakers Platform. "
+    "Через нашу мини-аппу ты можешь посмотреть расписание выступлений и спикеров. "
+    "Нажми кнопку 'MiniApp' в меню, чтобы открыть мини‑приложение."
+)
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(WELCOME_TEXT)
+
+async def setup_menu(app: Application) -> None:
+    button = MenuButtonWebApp(text="MiniApp", web_app=WebAppInfo(url=WEBAPP_URL))
+    await app.bot.set_chat_menu_button(menu_button=button)
+
+async def main() -> None:
+    if not TOKEN:
+        raise RuntimeError("BOT_TOKEN environment variable is not set")
+
+    app = Application.builder().token(TOKEN).build()
+    app.add_handler(CommandHandler("start", start))
+
+    await setup_menu(app)
+    await app.run_polling()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 Pillow
+python-telegram-bot>=20.0


### PR DESCRIPTION
## Summary
- add `python-telegram-bot` to requirements
- create `bot.py` that sends a welcome message and configures a MiniApp menu button
- document bot usage in README

## Testing
- `python -m py_compile bot.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6867f836424483289705f316c6b18b01