### PR TITLE
Implement debug/prod modes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 ADMIN_USERNAMES=daniil123,kate_dev,ivan_qalead
+# Режим работы приложения: debug или prod
+# MODE=prod
 # Путь к файлу базы данных (необязательный)
 # DB_PATH=/data/db.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Speakers Platform Telegram Mini App
 
-This project contains a tiny Flask backend and a static front‑end written in React. It showcases speakers and their talks inside a Telegram WebApp.
+This project contains a tiny Flask backend and a static front-end written in React. It showcases speakers and their talks inside a Telegram WebApp.
 
 Data is stored in `/data/db.json` by default (the location can be changed via the `DB_PATH` environment variable).
 
@@ -11,4 +11,10 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Open `http://localhost:5000/` to see the demo cards. Visit `/admin` for the admin placeholder.
+Open `http://localhost:5000/` to see the demo cards. Visit `/admin` for the admin panel.
+
+## Configuration
+
+Settings are loaded from `.env`.
+- `MODE` can be `debug` or `prod` (defaults to `prod`).
+- `ADMIN_USERNAMES` is a comma separated list of Telegram usernames allowed to access the admin panel in `prod` mode.

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -20,9 +20,24 @@
   <main id="admin-root" class="admin-content"></main>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
-    <a href="/admin" class="active" title="Админка">⚙️</a>
+    <a href="/admin" id="admin-link" class="active" title="Админка">⚙️</a>
     <a href="/profile" title="Личный кабинет">👤</a>
   </nav>
+  <script src="/config.js"></script>
+  <script>
+    (function() {
+      const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
+      const tg = window.Telegram?.WebApp;
+      const user = tg?.initDataUnsafe?.user;
+      const isAdmin = user && cfg.admins.includes(user.username);
+      if (cfg.mode === 'prod' && !isAdmin) {
+        document.getElementById('admin-link')?.remove();
+        document.querySelector('main.admin-content').innerHTML = 'Доступ запрещён';
+        return;
+      }
+      tg?.expand();
+    })();
+  </script>
   <script type="module" src="admin.js"></script>
 </body>
 </html>

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -3,7 +3,8 @@ import { DIRECTIONS } from './directions.js';
 const e = React.createElement;
 const { useState, useEffect } = React;
 
-const ALLOWED_USERS = ['admin'];
+const APP_CFG = window.APP_CONFIG || { mode: 'prod', admins: [] };
+const ALLOWED_USERS = APP_CFG.admins;
 
 function SpeakerForm({ initial = {}, onSubmit, onCancel }) {
   const [name, setName] = useState(initial.name || '');
@@ -134,7 +135,11 @@ function AdminApp() {
       const user = tg?.initDataUnsafe?.user;
       if (user) {
         setUsername(user.username);
-        setAuthorized(ALLOWED_USERS.includes(user.username));
+        if (APP_CFG.mode === 'debug') {
+          setAuthorized(true);
+        } else {
+          setAuthorized(ALLOWED_USERS.includes(user.username));
+        }
       }
       tg?.expand();
       try {
@@ -214,9 +219,9 @@ function AdminApp() {
     }
   };
 
-  // if (!authorized) {
-  //   return e('div', null, 'Доступ запрещен для ', username || 'guest');
-  // }
+  if (APP_CFG.mode === 'prod' && !authorized) {
+    return e('div', null, 'Доступ запрещён для ', username || 'guest');
+  }
 
   const speakerSection = editingSpeaker ?
     e(SpeakerForm, { initial: editingSpeaker, onSubmit: saveSpeaker, onCancel: () => setEditingSpeaker(null) }) :

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,9 +19,22 @@
   <div id="bottom-sheet-root"></div>
   <nav class="bottom-nav">
     <a href="/" class="active" title="Выступления">🎤</a>
-    <a href="/admin" title="Админка">⚙️</a>
+    <a href="/admin" id="admin-link" title="Админка">⚙️</a>
     <a href="/profile" title="Личный кабинет">👤</a>
   </nav>
+  <script src="/config.js"></script>
+  <script>
+    (function() {
+      const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
+      const tg = window.Telegram?.WebApp;
+      const user = tg?.initDataUnsafe?.user;
+      const isAdmin = user && cfg.admins.includes(user.username);
+      if (cfg.mode === 'prod' && !isAdmin) {
+        document.getElementById('admin-link')?.remove();
+      }
+      tg?.expand();
+    })();
+  </script>
   <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -14,9 +14,22 @@
   <div id="profile-root"></div>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
-    <a href="/admin" title="Админка">⚙️</a>
+    <a href="/admin" id="admin-link" title="Админка">⚙️</a>
     <a href="/profile" class="active" title="Личный кабинет">👤</a>
   </nav>
+  <script src="/config.js"></script>
+  <script>
+    (function() {
+      const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
+      const tg = window.Telegram?.WebApp;
+      const user = tg?.initDataUnsafe?.user;
+      const isAdmin = user && cfg.admins.includes(user.username);
+      if (cfg.mode === 'prod' && !isAdmin) {
+        document.getElementById('admin-link')?.remove();
+      }
+      tg?.expand();
+    })();
+  </script>
   <script type="module" src="profile.js"></script>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 Pillow
+python-dotenv


### PR DESCRIPTION
## Summary
- add configuration loading with `python-dotenv`
- implement `MODE` and `ADMIN_USERNAMES` settings
- generate `/config.js` with current mode and admins
- hide admin UI links if user is not in `ADMIN_USERNAMES` when in prod mode
- restrict admin page in prod mode
- update README and `.env.example`

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `MODE=debug ADMIN_USERNAMES=admin python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68683b028a9c8328abdcd86781d93acc