### PR TITLE
Fix MODE from .env overriding environment

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import datetime
 from io import BytesIO
 from PIL import Image
 
-load_dotenv()
+load_dotenv(override=True)
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- ensure environment variables defined in `.env` override system variables

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68691a58b5a08328b2222a77747975f3