### PR TITLE
Improve admin UI layout

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -4,6 +4,8 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  background: #f5f5f5;
+  color: #000;
 }
 
 .admin-page header {
@@ -29,15 +31,27 @@
   flex: 1;
 }
 
-.admin-list > div {
+.admin-list-item {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  flex-direction: column;
   background: #fff;
+  color: #000;
   padding: 10px;
   margin-bottom: 10px;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.admin-item-name {
+  font-weight: 600;
+  word-break: break-word;
+}
+
+.admin-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
 }
 
 .admin-form label {

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -227,12 +227,12 @@ function AdminApp() {
     e(SpeakerForm, { initial: editingSpeaker, onSubmit: saveSpeaker, onCancel: () => setEditingSpeaker(null) }) :
     e('div', { className: 'admin-list' },
       e('button', { onClick: () => setEditingSpeaker({}) }, 'Добавить спикера'),
-      speakers.map(s => e('div', { key: s.id },
-        e('span', null, s.name),
-        ' ',
-        e('button', { onClick: () => setEditingSpeaker(s) }, 'Редактировать'),
-        ' ',
-        e('button', { onClick: () => deleteSpeaker(s.id) }, 'Удалить')
+      speakers.map(s => e('div', { key: s.id, className: 'admin-list-item' },
+        e('span', { className: 'admin-item-name' }, s.name),
+        e('div', { className: 'admin-actions' },
+          e('button', { onClick: () => setEditingSpeaker(s) }, 'Редактировать'),
+          e('button', { onClick: () => deleteSpeaker(s.id) }, 'Удалить')
+        )
       ))
     );
 
@@ -240,12 +240,12 @@ function AdminApp() {
     e(TalkForm, { initial: editingTalk, speakers, onSubmit: saveTalk, onCancel: () => setEditingTalk(null) }) :
     e('div', { className: 'admin-list' },
       e('button', { onClick: () => setEditingTalk({}) }, 'Добавить выступление'),
-      talks.map(t => e('div', { key: t.id },
-        e('span', null, t.title),
-        ' (', speakers.find(s => s.id === t.speakerId)?.name || '', ') ',
-        e('button', { onClick: () => setEditingTalk(t) }, 'Редактировать'),
-        ' ',
-        e('button', { onClick: () => deleteTalk(t.id) }, 'Удалить')
+      talks.map(t => e('div', { key: t.id, className: 'admin-list-item' },
+        e('span', { className: 'admin-item-name' }, `${t.title} (${speakers.find(s => s.id === t.speakerId)?.name || ''})`),
+        e('div', { className: 'admin-actions' },
+          e('button', { onClick: () => setEditingTalk(t) }, 'Редактировать'),
+          e('button', { onClick: () => deleteTalk(t.id) }, 'Удалить')
+        )
       ))
     );
 


### PR DESCRIPTION
## Summary
- fix admin background and text color for readability
- restructure admin speaker/talk items with better layout
- style admin list items with spacing so buttons don't overlap

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b80c6bda88328a89eeb24535d7b34