### PR TITLE
Improve admin UI scrolling and spacing

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -21,6 +21,29 @@
   padding-bottom: 70px; /* space for bottom nav */
 }
 
+/* Allow content inside tabs to scroll if it exceeds the viewport */
+.admin-form,
+.admin-list {
+  overflow-y: auto;
+  max-height: calc(100vh - 200px);
+}
+
+.admin-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.admin-list {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Add spacing after the "Add" buttons */
+.admin-list > button {
+  margin-bottom: 10px;
+}
+
 .admin-tabs {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
## Summary
- allow scrolling of forms and speaker lists in the admin panel
- add margin after the "Add" buttons

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ba9857a2883288d2c74193beed390