### PR TITLE
Fix bottom nav overlap on profile page

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -16,6 +16,11 @@ body {
   color: #fff;
 }
 
+#profile-root {
+  padding: 10px;
+  padding-bottom: 70px; /* reserve space for bottom navigation */
+}
+
 #root {
   padding: 10px;
   padding-bottom: 150px; /* space for bottom nav and bottom sheet */


### PR DESCRIPTION
## Summary
- reserve space for bottom navigation on profile page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686bae4c90dc8328a2829e26e1733e2b