### PR TITLE
Fix body scrolling under fixed bottom nav

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -12,7 +12,9 @@ body {
   background: linear-gradient(180deg, #cf00ff 0%, #3100ff 100%);
   background-attachment: fixed;
   min-height: 100vh;
-  overflow: hidden;
+  /* allow scrolling so content isn't hidden behind the fixed nav */
+  overflow-x: hidden;
+  overflow-y: auto;
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- allow page body to scroll so content isn't clipped behind the fixed nav

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686bb1e056948328b31ae620181e05d6