### PR TITLE
Switch admin actions to icons

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -59,7 +59,8 @@
 
 .admin-list-item {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   background: #fff;
   color: #000;
   padding: 10px;
@@ -71,13 +72,22 @@
 .admin-item-name {
   font-weight: 600;
   word-break: break-word;
+  flex: 1;
 }
 
 .admin-actions {
   display: flex;
   gap: 8px;
-  flex-wrap: wrap;
-  margin-top: 8px;
+  flex-wrap: nowrap;
+  margin-top: 0;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  padding: 4px;
+  cursor: pointer;
+  font-size: 20px;
 }
 
 .admin-form label {

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -230,8 +230,16 @@ function AdminApp() {
       speakers.map(s => e('div', { key: s.id, className: 'admin-list-item' },
         e('span', { className: 'admin-item-name' }, s.name),
         e('div', { className: 'admin-actions' },
-          e('button', { onClick: () => setEditingSpeaker(s) }, 'Редактировать'),
-          e('button', { onClick: () => deleteSpeaker(s.id) }, 'Удалить')
+          e('button', {
+            className: 'icon-btn',
+            title: 'Редактировать',
+            onClick: () => setEditingSpeaker(s)
+          }, '✏️'),
+          e('button', {
+            className: 'icon-btn',
+            title: 'Удалить',
+            onClick: () => window.confirm('Удалить спикера?') && deleteSpeaker(s.id)
+          }, '🗑️')
         )
       ))
     );
@@ -243,8 +251,16 @@ function AdminApp() {
       talks.map(t => e('div', { key: t.id, className: 'admin-list-item' },
         e('span', { className: 'admin-item-name' }, `${t.title} (${speakers.find(s => s.id === t.speakerId)?.name || ''})`),
         e('div', { className: 'admin-actions' },
-          e('button', { onClick: () => setEditingTalk(t) }, 'Редактировать'),
-          e('button', { onClick: () => deleteTalk(t.id) }, 'Удалить')
+          e('button', {
+            className: 'icon-btn',
+            title: 'Редактировать',
+            onClick: () => setEditingTalk(t)
+          }, '✏️'),
+          e('button', {
+            className: 'icon-btn',
+            title: 'Удалить',
+            onClick: () => window.confirm('Удалить выступление?') && deleteTalk(t.id)
+          }, '🗑️')
         )
       ))
     );


### PR DESCRIPTION
## Summary
- replace Edit/Delete buttons with icons in admin UI
- keep icons on the right side with flex layout
- ask for confirmation before deleting items

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686bb75abd3c8328a905960a50e4b4db