### PR TITLE
Fix overlap with bottom menu

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -3,6 +3,8 @@
   --speaker-top: 20px;
   /* Slightly reduce the height so prev/next speakers remain visible */
   --speaker-height: 50vh;
+  /* Height of the fixed bottom navigation */
+  --bottom-nav-height: 70px;
 }
 
 html, body {
@@ -76,7 +78,8 @@ body {
 .swiper-container {
   width: 100%;
   padding-top: 40px;
-  padding-bottom: 40px;
+  /* keep last slide content above the fixed nav */
+  padding-bottom: calc(40px + var(--bottom-nav-height));
 }
 
 .swiper-slide {
@@ -291,6 +294,8 @@ form select {
   list-style: none;
   padding: 0;
   margin-top: 60px;
+  /* avoid overlap with the fixed bottom navigation */
+  padding-bottom: var(--bottom-nav-height);
 }
 
 .talk-list li {


### PR DESCRIPTION
## Summary
- account for fixed bottom navigation
- add CSS variable for bottom menu height
- pad Swiper container and list views to avoid overlap

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686bbd9abebc8328b98d263769c24740