### PR TITLE
Fix bottom sheet scrolling under nav

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -72,11 +72,15 @@ function BottomSheet({ talk, speaker }) {
     'div',
     { className: 'bottom-sheet', style: { borderTop: `8px solid ${accent}` } },
     e('div', { className: 'handle' }),
-    e('h3', null, talk.title),
-    e('div', { className: 'sheet-speaker' }, speaker?.name || ''),
-    e('div', null, talk.description),
-    e('div', { className: 'sheet-event' }, talk.eventName),
-    link
+    e(
+      'div',
+      { className: 'sheet-content' },
+      e('h3', null, talk.title),
+      e('div', { className: 'sheet-speaker' }, speaker?.name || ''),
+      e('div', null, talk.description),
+      e('div', { className: 'sheet-event' }, talk.eventName),
+      link
+    )
   );
 }
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -167,16 +167,23 @@ form select {
 .bottom-sheet {
   position: fixed;
   top: calc(var(--speaker-top) + var(--speaker-height));
-  bottom: calc(60px + env(safe-area-inset-bottom));
+  bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom));
   left: 0;
   right: 0;
   background: #111;
   color: #fff;
   padding: 24px;
   border-radius: 20px 20px 0 0;
-  overflow-y: auto;
-  max-height: calc(100vh - var(--speaker-top) - var(--speaker-height) - 60px - env(safe-area-inset-bottom));
+  overflow: hidden;
+  max-height: calc(100vh - var(--speaker-top) - var(--speaker-height) - var(--bottom-nav-height) - env(safe-area-inset-bottom));
   min-height: 40vh;
+}
+
+.bottom-sheet .sheet-content {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  max-height: 100%;
+  padding-bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom));
 }
 
 .bottom-sheet .handle {


### PR DESCRIPTION
## Summary
- keep fixed bottom nav from overlapping content by adjusting bottom sheet
- make sheet content scrollable with safe padding

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686bc172f7588328ad5ef347c9779842