### PR TITLE
Fix bottom sheet content overflow

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -4,7 +4,8 @@
   /* Slightly reduce the height so prev/next speakers remain visible */
   --speaker-height: 50vh;
   /* Height of the fixed bottom navigation */
-  --bottom-nav-height: 70px;
+  /* Height of the fixed bottom navigation. */
+  --bottom-nav-height: 64px;
 }
 
 html, body {
@@ -28,7 +29,9 @@ body {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   /* reserve space for bottom navigation and safe areas */
-  padding-bottom: calc(70px + env(safe-area-inset-bottom));
+  padding-bottom: calc(
+    var(--bottom-nav-height) + env(safe-area-inset-bottom)
+  );
 }
 
 #root {
@@ -184,7 +187,10 @@ form select {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   max-height: 100%;
-  padding-bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom));
+  /* ensure last items aren't hidden under the nav */
+  padding-bottom: calc(
+    var(--bottom-nav-height) + 16px + env(safe-area-inset-bottom)
+  );
 }
 
 .bottom-sheet .handle {
@@ -303,7 +309,9 @@ form select {
   padding: 0;
   margin-top: 60px;
   /* avoid overlap with the fixed bottom navigation */
-  padding-bottom: var(--bottom-nav-height);
+  padding-bottom: calc(
+    var(--bottom-nav-height) + env(safe-area-inset-bottom)
+  );
 }
 
 .talk-list li {


### PR DESCRIPTION
## Summary
- tweak mobile layout constants
- ensure bottom sheet has extra space for fixed navigation
- adjust talk list and profile page padding

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686bc7dc638c8328acab6dfbcea44928