### PR TITLE
Add statistics page

### DIFF
--- a/app.py
+++ b/app.py
@@ -182,6 +182,11 @@ def profile_page():
     return send_from_directory('frontend', 'profile.html')
 
 
+@app.route('/stats')
+def stats_page():
+    return send_from_directory('frontend', 'stats.html')
+
+
 @app.route('/<path:path>')
 def static_proxy(path):
     return send_from_directory('frontend', path)

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -20,6 +20,7 @@
   <main id="admin-root" class="admin-content"></main>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
+    <a href="/stats" title="Статистика">📊</a>
     <a href="/admin" id="admin-link" class="active" title="Админка">⚙️</a>
     <a href="/profile" title="Личный кабинет">👤</a>
   </nav>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -14,6 +14,7 @@
   <div id="profile-root"></div>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
+    <a href="/stats" title="Статистика">📊</a>
     <a href="/admin" id="admin-link" title="Админка">⚙️</a>
     <a href="/profile" class="active" title="Личный кабинет">👤</a>
   </nav>

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -3,23 +3,22 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Speakers Platform</title>
-  <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
+  <title>Statistics</title>
   <link rel="stylesheet" href="styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
-  <!-- React and dependencies from CDN -->
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <!-- Telegram WebApp JS to access Telegram features -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-  <div id="root"></div>
-  <div id="bottom-sheet-root"></div>
+  <div class="stats-wrapper">
+    <canvas id="talks-chart"></canvas>
+    <canvas id="speakers-chart"></canvas>
+  </div>
   <nav class="bottom-nav">
-    <a href="/" class="active" title="Выступления">🎤</a>
-    <a href="/stats" title="Статистика">📊</a>
+    <a href="/" title="Выступления">🎤</a>
+    <a href="/stats" class="active" title="Статистика">📊</a>
     <a href="/admin" id="admin-link" title="Админка">⚙️</a>
     <a href="/profile" title="Личный кабинет">👤</a>
   </nav>
@@ -36,6 +35,6 @@
       tg?.expand();
     })();
   </script>
-  <script type="module" src="app.js"></script>
+  <script type="module" src="stats.js"></script>
 </body>
 </html>

--- a/frontend/stats.js
+++ b/frontend/stats.js
@@ -1,0 +1,75 @@
+import { DIRECTIONS } from './directions.js';
+
+const ACCENTS = {
+  frontend: '#4caf50',
+  backend: '#795548',
+  QA: '#9c27b0',
+  mobile: '#ff9800',
+  product: '#f44336',
+  data: '#2196f3',
+  manager: '#607d8b'
+};
+
+async function loadData() {
+  try {
+    const [speakersRes, talksRes] = await Promise.all([
+      fetch('/api/speakers'),
+      fetch('/api/talks')
+    ]);
+    if (!speakersRes.ok || !talksRes.ok) throw new Error('Fetch error');
+    const [speakers, talks] = await Promise.all([
+      speakersRes.json(),
+      talksRes.json()
+    ]);
+    renderCharts(speakers, talks);
+  } catch (err) {
+    document.querySelector('.stats-wrapper').innerText = 'Не удалось загрузить данные';
+  }
+}
+
+function renderCharts(speakers, talks) {
+  const talkCount = {};
+  const speakerSets = {};
+  DIRECTIONS.forEach(d => {
+    talkCount[d] = 0;
+    speakerSets[d] = new Set();
+  });
+
+  talks.forEach(t => {
+    if (talkCount[t.direction] !== undefined) {
+      talkCount[t.direction]++;
+      speakerSets[t.direction].add(t.speakerId);
+    }
+  });
+
+  const activeSpeakers = DIRECTIONS.map(d => speakerSets[d].size);
+
+  const ctx1 = document.getElementById('talks-chart').getContext('2d');
+  new Chart(ctx1, {
+    type: 'bar',
+    data: {
+      labels: DIRECTIONS,
+      datasets: [{
+        data: DIRECTIONS.map(d => talkCount[d]),
+        backgroundColor: DIRECTIONS.map(d => ACCENTS[d] || '#ccc')
+      }]
+    },
+    options: {
+      plugins: { legend: { display: false } }
+    }
+  });
+
+  const ctx2 = document.getElementById('speakers-chart').getContext('2d');
+  new Chart(ctx2, {
+    type: 'pie',
+    data: {
+      labels: DIRECTIONS,
+      datasets: [{
+        data: activeSpeakers,
+        backgroundColor: DIRECTIONS.map(d => ACCENTS[d] || '#ccc')
+      }]
+    }
+  });
+}
+
+loadData();

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -349,3 +349,19 @@ form select {
     transform: scale(1);
   }
 }
+
+/* Statistics page */
+.stats-wrapper {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  /* leave space for bottom nav */
+  padding-bottom: calc(20px + var(--bottom-nav-height) + env(safe-area-inset-bottom));
+}
+
+.stats-wrapper canvas {
+  background: rgba(0,0,0,0.4);
+  border-radius: 8px;
+  padding: 10px;
+}


### PR DESCRIPTION
## Summary
- add new statistics page
- draw bar chart for talk counts by direction and pie chart for active speaker counts
- link statistics page in navigation

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686bd0a02e208328a1f9ea44005dc7b1