### PR TITLE
Update stats page theme

### DIFF
--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -11,7 +11,7 @@
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
-<body>
+<body class="stats-page">
   <div class="stats-wrapper">
     <div class="chart-block">
       <h3 class="chart-title">Доклады по направлениям</h3>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -24,6 +24,12 @@ body {
   color: #fff;
 }
 
+/* Light theme for statistics page */
+.stats-page {
+  background: #f5f5f5;
+  color: #000;
+}
+
 #profile-root {
   padding: 10px;
   height: 100%;


### PR DESCRIPTION
## Summary
- lighten background on statistics page similar to admin page
- set dark text on statistics page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686be415145c83288b93dc0836590eee