### PR TITLE
Restrict admin and stats pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,6 +167,18 @@ def config_js():
     )
     return Response(js, mimetype='application/javascript')
 
+
+def is_admin_request(req: request) -> bool:
+    """Check if the current request belongs to an admin user."""
+    if MODE == 'debug':
+        return True
+    username = (
+        req.cookies.get('username')
+        or req.headers.get('X-Username')
+        or req.args.get('u')
+    )
+    return username in ADMIN_USERNAMES
+
 @app.route('/')
 def index():
     return send_from_directory('frontend', 'index.html')
@@ -174,6 +186,8 @@ def index():
 
 @app.route('/admin')
 def admin_page():
+    if not is_admin_request(request):
+        return abort(403)
     return send_from_directory('frontend', 'admin.html')
 
 
@@ -184,6 +198,8 @@ def profile_page():
 
 @app.route('/stats')
 def stats_page():
+    if not is_admin_request(request):
+        return abort(403)
     return send_from_directory('frontend', 'stats.html')
 
 

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -30,6 +30,9 @@
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
       const tg = window.Telegram?.WebApp;
       const user = tg?.initDataUnsafe?.user;
+      if (user && user.username) {
+        document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
+      }
       const isAdmin = user && cfg.admins.includes(user.username);
       if (cfg.mode === 'prod' && !isAdmin) {
         document.getElementById('admin-link')?.remove();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,6 +29,9 @@
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
       const tg = window.Telegram?.WebApp;
       const user = tg?.initDataUnsafe?.user;
+      if (user && user.username) {
+        document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
+      }
       const isAdmin = user && cfg.admins.includes(user.username);
       if (cfg.mode === 'prod' && !isAdmin) {
         document.getElementById('admin-link')?.remove();

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -24,6 +24,9 @@
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
       const tg = window.Telegram?.WebApp;
       const user = tg?.initDataUnsafe?.user;
+      if (user && user.username) {
+        document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
+      }
       const isAdmin = user && cfg.admins.includes(user.username);
       if (cfg.mode === 'prod' && !isAdmin) {
         document.getElementById('admin-link')?.remove();

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -34,6 +34,9 @@
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
       const tg = window.Telegram?.WebApp;
       const user = tg?.initDataUnsafe?.user;
+      if (user && user.username) {
+        document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
+      }
       const isAdmin = user && cfg.admins.includes(user.username);
       if (cfg.mode === 'prod' && !isAdmin) {
         document.getElementById('admin-link')?.remove();


### PR DESCRIPTION
## Summary
- block access to admin/stats unless user is admin
- store telegram username in a cookie on all pages

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686be6bfcc748328a343a21f0911fc54