### PR TITLE
Show stats only for admins

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -20,7 +20,7 @@
   <main id="admin-root" class="admin-content"></main>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
-    <a href="/stats" title="Статистика">📊</a>
+    <a href="/stats" id="stats-link" title="Статистика">📊</a>
     <a href="/admin" id="admin-link" class="active" title="Админка">⚙️</a>
     <a href="/profile" title="Личный кабинет">👤</a>
   </nav>
@@ -36,6 +36,7 @@
       const isAdmin = user && cfg.admins.includes(user.username);
       if (cfg.mode === 'prod' && !isAdmin) {
         document.getElementById('admin-link')?.remove();
+        document.getElementById('stats-link')?.remove();
         document.querySelector('main.admin-content').innerHTML = 'Доступ запрещён';
         return;
       }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,7 +19,7 @@
   <div id="bottom-sheet-root"></div>
   <nav class="bottom-nav">
     <a href="/" class="active" title="Выступления">🎤</a>
-    <a href="/stats" title="Статистика">📊</a>
+    <a href="/stats" id="stats-link" title="Статистика">📊</a>
     <a href="/admin" id="admin-link" title="Админка">⚙️</a>
     <a href="/profile" title="Личный кабинет">👤</a>
   </nav>
@@ -35,6 +35,7 @@
       const isAdmin = user && cfg.admins.includes(user.username);
       if (cfg.mode === 'prod' && !isAdmin) {
         document.getElementById('admin-link')?.remove();
+        document.getElementById('stats-link')?.remove();
       }
       tg?.expand();
     })();

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -14,7 +14,7 @@
   <div id="profile-root"></div>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
-    <a href="/stats" title="Статистика">📊</a>
+    <a href="/stats" id="stats-link" title="Статистика">📊</a>
     <a href="/admin" id="admin-link" title="Админка">⚙️</a>
     <a href="/profile" class="active" title="Личный кабинет">👤</a>
   </nav>
@@ -30,6 +30,7 @@
       const isAdmin = user && cfg.admins.includes(user.username);
       if (cfg.mode === 'prod' && !isAdmin) {
         document.getElementById('admin-link')?.remove();
+        document.getElementById('stats-link')?.remove();
       }
       tg?.expand();
     })();

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -24,7 +24,7 @@
   </div>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
-    <a href="/stats" class="active" title="Статистика">📊</a>
+    <a href="/stats" id="stats-link" class="active" title="Статистика">📊</a>
     <a href="/admin" id="admin-link" title="Админка">⚙️</a>
     <a href="/profile" title="Личный кабинет">👤</a>
   </nav>
@@ -40,6 +40,7 @@
       const isAdmin = user && cfg.admins.includes(user.username);
       if (cfg.mode === 'prod' && !isAdmin) {
         document.getElementById('admin-link')?.remove();
+        document.getElementById('stats-link')?.remove();
       }
       tg?.expand();
     })();


### PR DESCRIPTION
## Summary
- hide statistics link when not admin

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686bf0742e648328a22fd78e00cbdb03