### PR TITLE
Fix stats visibility for non-admins

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -34,7 +34,7 @@
         document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
       }
       const isAdmin = user && cfg.admins.includes(user.username);
-      if (cfg.mode === 'prod' && !isAdmin) {
+      if (cfg.mode !== 'debug' && !isAdmin) {
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
         document.querySelector('main.admin-content').innerHTML = 'Доступ запрещён';

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -219,7 +219,7 @@ function AdminApp() {
     }
   };
 
-  if (APP_CFG.mode === 'prod' && !authorized) {
+  if (APP_CFG.mode !== 'debug' && !authorized) {
     return e('div', null, 'Доступ запрещён для ', username || 'guest');
   }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,7 +33,7 @@
         document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
       }
       const isAdmin = user && cfg.admins.includes(user.username);
-      if (cfg.mode === 'prod' && !isAdmin) {
+      if (cfg.mode !== 'debug' && !isAdmin) {
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -28,7 +28,7 @@
         document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
       }
       const isAdmin = user && cfg.admins.includes(user.username);
-      if (cfg.mode === 'prod' && !isAdmin) {
+      if (cfg.mode !== 'debug' && !isAdmin) {
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -38,7 +38,7 @@
         document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
       }
       const isAdmin = user && cfg.admins.includes(user.username);
-      if (cfg.mode === 'prod' && !isAdmin) {
+      if (cfg.mode !== 'debug' && !isAdmin) {
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }


### PR DESCRIPTION
## Summary
- hide stats icon unless running in debug mode and user is admin
- enforce admin check in admin panel when not in debug mode

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686bf39ac1bc832883a9bb0c8de664c3