### PR TITLE
Enable pull-to-expand bottom sheet

### DIFF
--- a/frontend/components/BottomSheet.js
+++ b/frontend/components/BottomSheet.js
@@ -5,6 +5,34 @@ export function BottomSheet({ talk, speaker }) {
   if (!talk) return null;
 
   const accent = ACCENTS[talk.direction] || '#03a9f4';
+  const [expanded, setExpanded] = React.useState(false);
+  const startYRef = React.useRef(0);
+
+  const handleStart = ev => {
+    const y = ev.touches ? ev.touches[0].clientY : ev.clientY;
+    startYRef.current = y;
+    document.addEventListener('pointermove', handleMove);
+    document.addEventListener('pointerup', handleEnd);
+    document.addEventListener('touchmove', handleMove);
+    document.addEventListener('touchend', handleEnd);
+  };
+
+  const handleMove = ev => {
+    const y = ev.touches ? ev.touches[0].clientY : ev.clientY;
+    const diff = startYRef.current - y;
+    if (diff > 50) {
+      setExpanded(true);
+    } else if (diff < -50) {
+      setExpanded(false);
+    }
+  };
+
+  const handleEnd = () => {
+    document.removeEventListener('pointermove', handleMove);
+    document.removeEventListener('pointerup', handleEnd);
+    document.removeEventListener('touchmove', handleMove);
+    document.removeEventListener('touchend', handleEnd);
+  };
 
   const link =
     talk.status === 'past'
@@ -13,8 +41,11 @@ export function BottomSheet({ talk, speaker }) {
 
   return e(
     'div',
-    { className: 'bottom-sheet', style: { borderTop: `8px solid ${accent}` } },
-    e('div', { className: 'handle' }),
+    {
+      className: `bottom-sheet${expanded ? ' expanded' : ''}`,
+      style: { borderTop: `8px solid ${accent}` },
+    },
+    e('div', { className: 'handle', onPointerDown: handleStart, onTouchStart: handleStart }),
     e(
       'div',
       { className: 'sheet-content' },

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -196,6 +196,15 @@ form select {
     100vh - var(--speaker-top) - var(--speaker-height) - var(--bottom-nav-height) - env(safe-area-inset-bottom)
   );
   min-height: 40vh;
+  transition: top 0.3s ease, bottom 0.3s ease, border-radius 0.3s ease;
+}
+
+.bottom-sheet.expanded {
+  top: 0;
+  bottom: 0;
+  max-height: none;
+  height: calc(100vh - env(safe-area-inset-bottom));
+  border-radius: 0;
 }
 
 .bottom-sheet .sheet-content {
@@ -209,6 +218,11 @@ form select {
     var(--bottom-nav-height) + 16px + env(safe-area-inset-bottom)
   );
   flex: 1;
+}
+
+.bottom-sheet.expanded .sheet-content {
+  max-height: none;
+  padding-bottom: env(safe-area-inset-bottom);
 }
 
 .bottom-sheet .handle {


### PR DESCRIPTION
## Summary
- add interactive state to `BottomSheet` and track drag events
- style the bottom sheet so it can expand to full screen

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686bfc4b761c832894ad782c5b39d057