### PR TITLE
Fix bottom sheet stacking order

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -197,6 +197,7 @@ form select {
   );
   min-height: 40vh;
   transition: top 0.3s ease, bottom 0.3s ease, border-radius 0.3s ease;
+  z-index: 20;
 }
 
 .bottom-sheet.expanded {


### PR DESCRIPTION
## Summary
- ensure bottom sheet appears above swiper slides when expanding

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686bfec7e4d48328b5c5d8c3760fd337