### PR TITLE
Implement arrow toggle for bottom sheet

### DIFF
--- a/frontend/components/BottomSheet.js
+++ b/frontend/components/BottomSheet.js
@@ -45,7 +45,12 @@ export function BottomSheet({ talk, speaker }) {
       className: `bottom-sheet${expanded ? ' expanded' : ''}`,
       style: { borderTop: `8px solid ${accent}` },
     },
-    e('div', { className: 'handle', onPointerDown: handleStart, onTouchStart: handleStart }),
+    e('div', {
+      className: `handle${expanded ? ' arrow-down' : ''}`,
+      onPointerDown: handleStart,
+      onTouchStart: handleStart,
+      onClick: () => expanded && setExpanded(false),
+    }),
     e(
       'div',
       { className: 'sheet-content' },

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -234,6 +234,17 @@ form select {
   margin: 0 auto 8px;
 }
 
+.bottom-sheet .handle.arrow-down {
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 10px solid #aaa;
+  background: none;
+  border-radius: 0;
+  cursor: pointer;
+}
+
 .bottom-sheet h3 {
   margin: 0 0 8px 0;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- add arrow indicator for the bottom sheet when expanded
- allow clicking the arrow to close the sheet
- style the arrow to match the handle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c007c21188328ad9c3818a4abe2d5