### PR TITLE
Fix smooth speaker card transition

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -132,15 +132,8 @@ body {
   height: calc(var(--speaker-height) * 0.55);
   z-index: 1;
   margin-top: 25%;
-}
-
-.swiper-slide-prev .card img {
-  left: 60%;
-  opacity: 0.8;
-}
-
-.swiper-slide-next .card img {
-  right: 60%;
+  left: 50%;
+  transform: translateX(-50%);
   opacity: 0.8;
 }
 


### PR DESCRIPTION
## Summary
- keep prev/next speaker images horizontally centered when changing slides

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686c0dd238308328927c2a14dfc79993