### PR TITLE
Fix filter overlay layout

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -80,11 +80,17 @@ body {
 }
 
 .filters {
-  margin-bottom: 20px;
+  position: fixed;
+  top: 60px;
+  left: 16px;
+  right: 16px;
+  background: rgba(0, 0, 0, 0.8);
+  padding: 10px;
+  border-radius: 12px;
   display: none;
   flex-direction: column;
   gap: 10px;
-  margin-top: 10px;
+  z-index: 15;
 }
 .filters.show {
   display: flex;


### PR DESCRIPTION
## Summary
- keep speaker cards in place while filters are toggled
- overlay filter panel above content so the button doesn't block the inputs

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686c1256e89083288e34cac7a36b80e7