### PR TITLE
Prevent Telegram swipe close

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -20,6 +20,7 @@
   flex: 1;
   padding: 10px;
   overflow-y: auto;
+  overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   /* account for safe areas and fixed bottom navigation */
   padding-bottom: calc(70px + env(safe-area-inset-bottom));

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -19,6 +19,8 @@ html, body {
   height: 100%;
   margin: 0;
   padding: 0;
+  /* Prevent pull-down gesture from closing Telegram browser */
+  overscroll-behavior-y: contain;
 }
 
 body {
@@ -36,6 +38,7 @@ body {
   color: #000;
   height: 100%;
   overflow-y: auto;
+  overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -43,6 +46,7 @@ body {
   padding: 10px;
   height: 100%;
   overflow-y: auto;
+  overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   /* reserve space for bottom navigation and safe areas */
   padding-bottom: calc(
@@ -54,6 +58,7 @@ body {
   padding: 10px;
   height: 100%;
   overflow-y: auto;
+  overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   /* space for bottom nav, bottom sheet and safe areas */
   padding-bottom: calc(150px + env(safe-area-inset-bottom));


### PR DESCRIPTION
## Summary
- allow Telegram WebApp pages to handle pull-down without closing

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686caff13abc83289f31cf57a6bd62a2