### PR TITLE
Add slight overscroll slack to prevent Telegram collapse

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -20,6 +20,8 @@
   flex: 1;
   padding: 10px;
   overflow-y: auto;
+  /* allow slight pull-down to avoid Telegram browser minimization */
+  min-height: calc(100% + 20px);
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   /* account for safe areas and fixed bottom navigation */

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -37,6 +37,8 @@ body {
   background: #f5f5f5;
   color: #000;
   height: 100%;
+  /* allow slight pull-down to avoid Telegram browser minimization */
+  min-height: calc(100% + 20px);
   overflow-y: auto;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
@@ -45,6 +47,8 @@ body {
 #profile-root {
   padding: 10px;
   height: 100%;
+  /* allow slight pull-down to avoid Telegram browser minimization */
+  min-height: calc(100% + 20px);
   overflow-y: auto;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
@@ -57,6 +61,8 @@ body {
 #root {
   padding: 10px;
   height: 100%;
+  /* allow slight pull-down to avoid Telegram browser minimization */
+  min-height: calc(100% + 20px);
   overflow-y: auto;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
@@ -426,6 +432,8 @@ form select {
   display: flex;
   flex-direction: column;
   gap: 20px;
+  /* allow slight pull-down to avoid Telegram browser minimization */
+  min-height: calc(100% + 20px);
   /* leave space for bottom nav */
   padding-bottom: calc(20px + var(--bottom-nav-height) + env(safe-area-inset-bottom));
 }


### PR DESCRIPTION
## Summary
- tweak CSS so scroll containers are a bit taller than the viewport
- prevents Telegram in-app browser from collapsing by allowing a small pull-down

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb890ee08832893c3befb1e7198e3