### PR TITLE
Add safe Telegram WebApp expand checks

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -40,7 +40,16 @@
         document.querySelector('main.admin-content').innerHTML = 'Доступ запрещён';
         return;
       }
-      tg?.expand();
+      const tryExpand = () => {
+        if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.expand();
+        }
+      };
+      if (document.readyState === 'loading') {
+        window.addEventListener('DOMContentLoaded', tryExpand);
+      } else {
+        tryExpand();
+      }
     })();
   </script>
   <script type="module" src="admin.js"></script>

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -20,17 +20,19 @@ function AdminApp() {
 
   useEffect(() => {
     const load = async () => {
-      const tg = window.Telegram?.WebApp;
-      const user = tg?.initDataUnsafe?.user;
-      if (user) {
-        setUsername(user.username);
-      }
-      if (APP_CFG.mode === 'debug') {
-        setAuthorized(true);
-      } else if (user) {
-        setAuthorized(ALLOWED_USERS.includes(user.username));
-      }
-      tg?.expand();
+        const tg = window.Telegram?.WebApp;
+        const user = tg?.initDataUnsafe?.user;
+        if (user) {
+          setUsername(user.username);
+        }
+        if (APP_CFG.mode === 'debug') {
+          setAuthorized(true);
+        } else if (user) {
+          setAuthorized(ALLOWED_USERS.includes(user.username));
+        }
+        if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.expand();
+        }
       try {
         const [speakersRes, talksRes] = await Promise.all([
           fetch('/api/speakers'),

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -187,7 +187,17 @@ function App() {
         );
 }
 
-// Expand the Telegram WebApp if running inside Telegram
-window.Telegram?.WebApp?.expand();
+// Expand the Telegram WebApp on mobile if running inside Telegram
+const tryExpand = () => {
+  const tg = window.Telegram?.WebApp;
+  if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+    tg.expand();
+  }
+};
+if (document.readyState === 'loading') {
+  window.addEventListener('DOMContentLoaded', tryExpand);
+} else {
+  tryExpand();
+}
 
 ReactDOM.createRoot(document.getElementById('root')).render(e(App));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,7 +37,16 @@
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }
-      tg?.expand();
+      const tryExpand = () => {
+        if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.expand();
+        }
+      };
+      if (document.readyState === 'loading') {
+        window.addEventListener('DOMContentLoaded', tryExpand);
+      } else {
+        tryExpand();
+      }
     })();
   </script>
   <script type="module" src="app.js"></script>

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -32,7 +32,16 @@
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }
-      tg?.expand();
+      const tryExpand = () => {
+        if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.expand();
+        }
+      };
+      if (document.readyState === 'loading') {
+        window.addEventListener('DOMContentLoaded', tryExpand);
+      } else {
+        tryExpand();
+      }
     })();
   </script>
   <script type="module" src="profile.js"></script>

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -3,10 +3,12 @@ const { useEffect, useState } = React;
 
 function ProfileApp() {
   const [user, setUser] = useState(null);
-  useEffect(() => {
+    useEffect(() => {
     const tg = window.Telegram?.WebApp;
     setUser(tg?.initDataUnsafe?.user || null);
-    tg?.expand();
+    if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+      tg.expand();
+    }
   }, []);
 
   if (!user) {

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -42,7 +42,16 @@
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }
-      tg?.expand();
+      const tryExpand = () => {
+        if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.expand();
+        }
+      };
+      if (document.readyState === 'loading') {
+        window.addEventListener('DOMContentLoaded', tryExpand);
+      } else {
+        tryExpand();
+      }
     })();
   </script>
   <script type="module" src="stats.js"></script>


### PR DESCRIPTION
## Summary
- add mobile-only expand check to `index.html`
- add mobile-only expand check to admin page
- add mobile-only expand check to stats page
- add mobile-only expand check to profile page
- safeguard expand logic inside `admin.js`, `profile.js`, and `app.js`

## Testing
- `python -m py_compile app.py`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cc2fd1c1c8328b22aea86f4dac82e