### PR TITLE
Enable Telegram WebApp full‑screen mode

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -29,6 +29,7 @@
     (function() {
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
       const tg = window.Telegram?.WebApp;
+      tg?.ready();
       const user = tg?.initDataUnsafe?.user;
       if (user && user.username) {
         document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
@@ -42,6 +43,7 @@
       }
       const tryExpand = () => {
         if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.ready();
           tg.expand();
         }
       };

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -21,6 +21,7 @@ function AdminApp() {
   useEffect(() => {
     const load = async () => {
         const tg = window.Telegram?.WebApp;
+        tg?.ready();
         const user = tg?.initDataUnsafe?.user;
         if (user) {
           setUsername(user.username);
@@ -31,6 +32,7 @@ function AdminApp() {
           setAuthorized(ALLOWED_USERS.includes(user.username));
         }
         if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.ready();
           tg.expand();
         }
       try {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -190,6 +190,7 @@ function App() {
 // Expand the Telegram WebApp on mobile if running inside Telegram
 const tryExpand = () => {
   const tg = window.Telegram?.WebApp;
+  tg?.ready();
   if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
     tg.expand();
   }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,6 +28,7 @@
     (function() {
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
       const tg = window.Telegram?.WebApp;
+      tg?.ready();
       const user = tg?.initDataUnsafe?.user;
       if (user && user.username) {
         document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
@@ -39,6 +40,7 @@
       }
       const tryExpand = () => {
         if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.ready();
           tg.expand();
         }
       };

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -23,6 +23,7 @@
     (function() {
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
       const tg = window.Telegram?.WebApp;
+      tg?.ready();
       const user = tg?.initDataUnsafe?.user;
       if (user && user.username) {
         document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
@@ -34,6 +35,7 @@
       }
       const tryExpand = () => {
         if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.ready();
           tg.expand();
         }
       };

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -3,8 +3,9 @@ const { useEffect, useState } = React;
 
 function ProfileApp() {
   const [user, setUser] = useState(null);
-    useEffect(() => {
+  useEffect(() => {
     const tg = window.Telegram?.WebApp;
+    tg?.ready();
     setUser(tg?.initDataUnsafe?.user || null);
     if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
       tg.expand();

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -33,6 +33,7 @@
     (function() {
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
       const tg = window.Telegram?.WebApp;
+      tg?.ready();
       const user = tg?.initDataUnsafe?.user;
       if (user && user.username) {
         document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
@@ -44,6 +45,7 @@
       }
       const tryExpand = () => {
         if (tg && tg.initData && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
+          tg.ready();
           tg.expand();
         }
       };


### PR DESCRIPTION
## Summary
- call `Telegram.WebApp.ready()` right after getting the WebApp instance
- expand the Telegram interface after signaling readiness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc62246f88328813923471fe33296