### PR TITLE
Fix admin page height for Telegram WebApp

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -21,6 +21,7 @@
 
 .admin-content {
   flex: 1;
+  height: 100%;
   padding: 10px;
   overflow-y: auto;
   /* allow slight pull-down to avoid Telegram browser minimization */


### PR DESCRIPTION
## Summary
- ensure `.admin-content` fills available height by mirroring `#root` layout

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ccfa0997c8328b4c9d77a5b78e838