### PR TITLE
Fix scrolling on admin page

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -6,8 +6,8 @@
   min-height: 100vh;
   background: #f5f5f5;
   color: #000;
-  /* allow scrolling on long forms */
-  overflow-y: auto;
+  /* Scrolling handled by .admin-content */
+  overflow-y: hidden;
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -34,7 +34,8 @@ body {
 
 body.admin-page,
 html.admin-page {
-  overflow-y: auto !important;
+  /* Prevent body scrolling; admin-content handles it */
+  overflow-y: hidden;
   height: 100%;
 }
 


### PR DESCRIPTION
## Summary
- prevent body from scrolling on admin pages
- let `.admin-content` be the only scroll container

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ce997eabc832897fba74806133673