### PR TITLE
Fix admin content height

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -24,11 +24,10 @@
 
 .admin-content {
   flex: 1;
-  height: 100%;
   padding: 10px;
   overflow-y: auto;
   /* allow slight pull-down to avoid Telegram browser minimization */
-  min-height: calc(100% + 20px);
+  min-height: calc(100vh - var(--bottom-nav-height));
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   /* account for safe areas and fixed bottom navigation */


### PR DESCRIPTION
## Summary
- update admin page main content styles so the section fills viewport height

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686cea93d9a48328a4d669fbcbe3d04f