### PR TITLE
Fix admin tab navigation

### DIFF
--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -161,8 +161,18 @@ function AdminApp() {
   return e('div', null,
     error && e('div', { className: 'error' }, error),
     e('div', { className: 'admin-tabs' },
-      e('button', { onClick: () => setTab('speakers') }, 'Спикеры'),
-      e('button', { onClick: () => setTab('talks') }, 'Выступления')
+      e('button', {
+        onClick: () => {
+          setEditingSpeaker(null);
+          setTab('speakers');
+        }
+      }, 'Спикеры'),
+      e('button', {
+        onClick: () => {
+          setEditingTalk(null);
+          setTab('talks');
+        }
+      }, 'Выступления')
     ),
     tab === 'speakers' ? speakerSection : talkSection
   );


### PR DESCRIPTION
## Summary
- keep editing forms closed when switching tabs in admin panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf9697ebc832883d11cbdcb401add