### PR TITLE
Add tags to speakers

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -111,3 +111,15 @@
   margin-bottom: 10px;
 }
 
+.admin-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.admin-tags label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+

--- a/frontend/components/forms.js
+++ b/frontend/components/forms.js
@@ -1,4 +1,5 @@
 import { DIRECTIONS } from '../directions.js';
+import { TAGS } from '../tags.js';
 const e = React.createElement;
 const { useState } = React;
 
@@ -6,6 +7,7 @@ export function SpeakerForm({ initial = {}, onSubmit, onCancel }) {
   const [name, setName] = useState(initial.name || '');
   const [description, setDescription] = useState(initial.description || '');
   const [photoUrl, setPhotoUrl] = useState(initial.photoUrl || '');
+  const [tags, setTags] = useState(initial.tags || []);
   const [uploading, setUploading] = useState(false);
 
   const uploadFile = async f => {
@@ -24,7 +26,7 @@ export function SpeakerForm({ initial = {}, onSubmit, onCancel }) {
       className: 'admin-form',
       onSubmit: ev => {
         ev.preventDefault();
-        onSubmit({ ...initial, name, description, photoUrl });
+        onSubmit({ ...initial, name, description, photoUrl, tags });
       },
     },
     e('div', null, e('label', null, 'Имя'), e('input', { value: name, onChange: ev => setName(ev.target.value) })),
@@ -33,6 +35,33 @@ export function SpeakerForm({ initial = {}, onSubmit, onCancel }) {
       null,
       e('label', null, 'Описание'),
       e('textarea', { value: description, onChange: ev => setDescription(ev.target.value) })
+    ),
+    e(
+      'div',
+      { className: 'admin-tags' },
+      e('label', null, 'Теги'),
+      e(
+        'div',
+        null,
+        TAGS.map(t =>
+          e(
+            'label',
+            { key: t },
+            e('input', {
+              type: 'checkbox',
+              checked: tags.includes(t),
+              onChange: ev => {
+                if (ev.target.checked) {
+                  setTags([...tags, t]);
+                } else {
+                  setTags(tags.filter(x => x !== t));
+                }
+              },
+            }),
+            t
+          )
+        )
+      )
     ),
     e(
       'div',

--- a/frontend/tags.js
+++ b/frontend/tags.js
@@ -1,0 +1,2 @@
+export const TAGS = ['frontend','backend','QA','mobile','product','data','manager'];
+


### PR DESCRIPTION
## Summary
- add static tag list
- allow admins to set tags for speakers
- style checkbox list for speaker tags

## Testing
- `python -m py_compile app.py storage.py migrate_json_to_sqlite.py`


------
https://chatgpt.com/codex/tasks/task_e_686e71dd5c94832891a408149d9e1838