### PR TITLE
Adjust speaker height for active images

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2,7 +2,7 @@
   /* Lift speaker images higher on the screen */
   --speaker-top: 20px;
   /* Slightly reduce the height so prev/next speakers remain visible */
-  --speaker-height: 50vh;
+  --speaker-height: 40vh;
   /* Height of the fixed bottom navigation. */
   --bottom-nav-height: 64px;
   /* Approximate height of the sheet header + handle */
@@ -12,7 +12,7 @@
 /* When the bottom sheet is expanded, shrink and raise speaker images */
 body.sheet-expanded {
   --speaker-top: 4px;
-  --speaker-height: 30vh;
+  --speaker-height: 24vh;
 }
 
 html, body {


### PR DESCRIPTION
## Summary
- tweak the default speaker height to better accommodate active slides
- scale down speaker height in the expanded sheet

## Testing
- `python -m py_compile app.py migrate_json_to_sqlite.py storage.py`

------
https://chatgpt.com/codex/tasks/task_e_686eada503bc8328b9eeffd2c4a8f7e9