### PR TITLE
Fix swiper image offset

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -172,8 +172,8 @@ body.sheet-expanded .swiper-slide-next {
   height: calc(var(--speaker-height) * 0.55);
   /* neighbour speakers should still stay above the sheet */
   z-index: 15;
-  margin-top: 25%;
-  transform: translateX(-50%);
+  /* maintain vertical offset using transform instead of margin */
+  transform: translate(-50%, 25%);
   opacity: 0.8;
 }
 


### PR DESCRIPTION
## Summary
- switch neighbouring swiper card image vertical spacing to `transform`
- keep transitions smooth using the existing transition list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eafc7ddc483288e668a37903aa4f2