### PR TITLE
Support multiple speakers per talk

### DIFF
--- a/app.py
+++ b/app.py
@@ -83,10 +83,18 @@ def speaker_by_id(id):
 def talks():
     data = read_db()
     if request.method == 'GET':
-        talks = [ { **t, 'status': calc_status(t.get('date', '')) } for t in data['talks'] ]
+        talks = []
+        for t in data['talks']:
+            item = {**t}
+            if 'speakerId' in item:
+                item['speakerIds'] = [item.pop('speakerId')]
+            item['status'] = calc_status(item.get('date', ''))
+            talks.append(item)
         return jsonify(talks)
 
     body = request.get_json() or {}
+    if 'speakerId' in body:
+        body['speakerIds'] = [body.pop('speakerId')]
     new_talk = {'id': str(uuid4()), **body}
     new_talk['status'] = calc_status(new_talk.get('date', ''))
     data['talks'].append(new_talk)
@@ -108,7 +116,11 @@ def talk_by_id(id):
         return jsonify({'ok': True})
 
     body = request.get_json() or {}
+    if 'speakerId' in body:
+        body['speakerIds'] = [body.pop('speakerId')]
     talks[idx].update(body)
+    if 'speakerId' in talks[idx]:
+        talks[idx]['speakerIds'] = [talks[idx].pop('speakerId')]
     talks[idx]['status'] = calc_status(talks[idx].get('date', ''))
     write_db(data)
     return jsonify(talks[idx])

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -141,21 +141,24 @@ function AdminApp() {
     e(TalkForm, { initial: editingTalk, speakers, onSubmit: saveTalk, onCancel: () => setEditingTalk(null) }) :
     e('div', { className: 'admin-list' },
       e('button', { onClick: () => setEditingTalk({}) }, 'Добавить выступление'),
-      talks.map(t => e('div', { key: t.id, className: 'admin-list-item' },
-        e('span', { className: 'admin-item-name' }, `${t.title} (${speakers.find(s => s.id === t.speakerId)?.name || ''})`),
-        e('div', { className: 'admin-actions' },
-          e('button', {
-            className: 'icon-btn',
-            title: 'Редактировать',
-            onClick: () => setEditingTalk(t)
-          }, '✏️'),
-          e('button', {
-            className: 'icon-btn',
-            title: 'Удалить',
-            onClick: () => window.confirm('Удалить выступление?') && deleteTalk(t.id)
-          }, '🗑️')
-        )
-      ))
+      talks.map(t => {
+        const names = speakers.filter(s => (t.speakerIds || []).includes(s.id)).map(s => s.name).join(', ');
+        return e('div', { key: t.id, className: 'admin-list-item' },
+          e('span', { className: 'admin-item-name' }, `${t.title} (${names})`),
+          e('div', { className: 'admin-actions' },
+            e('button', {
+              className: 'icon-btn',
+              title: 'Редактировать',
+              onClick: () => setEditingTalk(t)
+            }, '✏️'),
+            e('button', {
+              className: 'icon-btn',
+              title: 'Удалить',
+              onClick: () => window.confirm('Удалить выступление?') && deleteTalk(t.id)
+            }, '🗑️')
+          )
+        );
+      })
     );
 
   return e('div', null,

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -22,7 +22,7 @@ const TEST_SPEAKERS = [
 const TEST_TALKS = [
   {
     id: '1',
-    speakerId: '1',
+    speakerIds: ['1'],
     title: 'React Basics',
     description: 'Intro to React',
     eventName: 'JS Conf',
@@ -33,7 +33,7 @@ const TEST_TALKS = [
   },
   {
     id: '2',
-    speakerId: '1',
+    speakerIds: ['1'],
     title: 'Past Talk',
     description: 'Something done',
     eventName: 'Old Conf',
@@ -68,7 +68,7 @@ function App() {
         ]);
         const merged = talks.map(t => ({
           ...t,
-          speaker: speakers.find(s => s.id === t.speakerId),
+          speakers: speakers.filter(s => (t.speakerIds || []).includes(s.id)),
         }));
         setTalks(merged);
       } catch (err) {
@@ -93,7 +93,7 @@ function App() {
       return;
     }
     const item = filtered[activeIndex];
-    sheetRoot.render(e(BottomSheet, { talk: item, speaker: item?.speaker }));
+    sheetRoot.render(e(BottomSheet, { talk: item, speakers: item?.speakers }));
   }, [activeIndex, filtered, viewMode]);
 
   useEffect(() => {
@@ -178,7 +178,7 @@ function App() {
                   key: t.id,
                   onClick: () => {},
                 },
-                e(Card, { talk: t, speaker: t.speaker })
+                e(Card, { talk: t, speakers: t.speakers })
               )
             )
             )

--- a/frontend/components/BottomSheet.js
+++ b/frontend/components/BottomSheet.js
@@ -1,7 +1,7 @@
 import { ACCENTS } from '../constants.js';
 const e = React.createElement;
 
-export function BottomSheet({ talk, speaker }) {
+export function BottomSheet({ talk, speakers = [] }) {
   if (!talk) return null;
 
   const accent = ACCENTS[talk.direction] || '#03a9f4';
@@ -67,7 +67,7 @@ export function BottomSheet({ talk, speaker }) {
       'div',
       { className: 'sheet-content' },
       e('h3', null, talk.title),
-      e('div', { className: 'sheet-speaker' }, speaker?.name || ''),
+      e('div', { className: 'sheet-speaker' }, speakers.map(s => s.name).join(', ')),
       e('div', null, talk.description),
       e('div', { className: 'sheet-event' }, talk.eventName),
       link

--- a/frontend/components/Card.js
+++ b/frontend/components/Card.js
@@ -1,9 +1,10 @@
 const e = React.createElement;
 
-export function Card({ talk, speaker }) {
+export function Card({ talk, speakers = [] }) {
+  const main = speakers[0] || {};
   return e(
     'div',
     { className: 'card' },
-    e('img', { src: speaker.photoUrl || '/default_icon.svg', alt: speaker.name })
+    e('img', { src: main.photoUrl || '/default_icon.svg', alt: main.name || '' })
   );
 }

--- a/frontend/components/TalkList.js
+++ b/frontend/components/TalkList.js
@@ -24,7 +24,7 @@ export function TalkList({ items }) {
         e(
           'div',
           null,
-          e('span', { className: 'list-speaker' }, t.speaker?.name || ''),
+          e('span', { className: 'list-speaker' }, (t.speakers || []).map(s => s.name).join(', ')),
           ' — ',
           e('span', { className: 'list-title' }, t.title)
         ),

--- a/frontend/components/forms.js
+++ b/frontend/components/forms.js
@@ -54,7 +54,7 @@ export function SpeakerForm({ initial = {}, onSubmit, onCancel }) {
 
 export function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
   const [title, setTitle] = useState(initial.title || '');
-  const [speakerId, setSpeakerId] = useState(initial.speakerId || (speakers[0]?.id || ''));
+  const [speakerIds, setSpeakerIds] = useState(initial.speakerIds || (speakers[0]?.id ? [speakers[0]?.id] : []));
   const [description, setDescription] = useState(initial.description || '');
   const [eventName, setEventName] = useState(initial.eventName || '');
   const [direction, setDirection] = useState(initial.direction || 'frontend');
@@ -66,14 +66,14 @@ export function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
 
   const handleSubmit = ev => {
     ev.preventDefault();
-    if (!speakerId || !title.trim() || !eventName.trim() || !direction || !date) {
+    if (!speakerIds.length || !title.trim() || !eventName.trim() || !direction || !date) {
       alert('Заполните обязательные поля');
       return;
     }
     onSubmit({
       ...initial,
       title,
-      speakerId,
+      speakerIds,
       description,
       eventName,
       direction,
@@ -90,10 +90,15 @@ export function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
     e(
       'div',
       null,
-      e('label', null, 'Спикер'),
+      e('label', null, 'Спикеры'),
       e(
         'select',
-        { value: speakerId, onChange: ev => setSpeakerId(ev.target.value), required: true },
+        {
+          multiple: true,
+          value: speakerIds,
+          onChange: ev => setSpeakerIds(Array.from(ev.target.selectedOptions).map(o => o.value)),
+          required: true,
+        },
         speakers.map(s => e('option', { key: s.id, value: s.id }, s.name))
       )
     ),

--- a/frontend/stats.js
+++ b/frontend/stats.js
@@ -29,7 +29,7 @@ function renderCharts(speakers, talks) {
   talks.forEach(t => {
     if (talkCount[t.direction] !== undefined) {
       talkCount[t.direction]++;
-      speakerSets[t.direction].add(t.speakerId);
+      (t.speakerIds || []).forEach(id => speakerSets[t.direction].add(id));
     }
   });
 


### PR DESCRIPTION
## Summary
- Allow talks to store multiple speakers by converting `speakerId` to `speakerIds` in API handlers
- Map each talk's `speakerIds` to speaker objects in the UI and pass them through components
- Update admin talk form and displays to select and show multiple speakers

## Testing
- `node --check frontend/app.js frontend/components/forms.js frontend/components/Card.js frontend/components/BottomSheet.js frontend/components/TalkList.js frontend/stats.js frontend/admin.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899ca2a6f908328846cbeb9f6188b77