### PR TITLE
Render multiple speakers in TalkList

### DIFF
--- a/frontend/components/TalkList.js
+++ b/frontend/components/TalkList.js
@@ -24,7 +24,11 @@ export function TalkList({ items }) {
         e(
           'div',
           null,
-          e('span', { className: 'list-speaker' }, (t.speakers || []).map(s => s.name).join(', ')),
+          e(
+            'span',
+            { className: 'list-speaker' },
+            t.speakers.map(s => s.name).join(', ')
+          ),
           ' — ',
           e('span', { className: 'list-title' }, t.title)
         ),


### PR DESCRIPTION
## Summary
- Display joined names of all speakers in TalkList

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899d998e2d883288f329d60af596e2b