### PR TITLE
Use speakerIds to derive speaker names for talk items

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -48,6 +48,7 @@ function App() {
   const [direction, setDirection] = useState('all');
   const [status, setStatus] = useState('all');
   const [talks, setTalks] = useState([]);
+  const [speakers, setSpeakers] = useState([]);
   const [error, setError] = useState(null);
   const [showFilters, setShowFilters] = useState(false);
   const [viewMode, setViewMode] = useState('cards'); // 'cards' or 'list'
@@ -62,15 +63,12 @@ function App() {
           fetch('/api/talks'),
         ]);
         if (!speakersRes.ok || !talksRes.ok) throw new Error('Fetch error');
-        const [speakers, talks] = await Promise.all([
+        const [speakersData, talksData] = await Promise.all([
           speakersRes.json(),
           talksRes.json(),
         ]);
-        const merged = talks.map(t => ({
-          ...t,
-          speakers: speakers.filter(s => (t.speakerIds || []).includes(s.id)),
-        }));
-        setTalks(merged);
+        setSpeakers(speakersData);
+        setTalks(talksData);
       } catch (err) {
         setError('Не удалось загрузить данные');
       }
@@ -87,14 +85,17 @@ function App() {
     setActiveIndex(0);
   }, [filtered.length]);
 
+  const getSpeakers = talk =>
+    speakers.filter(s => (talk?.speakerIds || []).includes(s.id));
+
   useEffect(() => {
     if (viewMode !== 'cards') {
       sheetRoot.render(null);
       return;
     }
     const item = filtered[activeIndex];
-    sheetRoot.render(e(BottomSheet, { talk: item, speakers: item?.speakers }));
-  }, [activeIndex, filtered, viewMode]);
+    sheetRoot.render(e(BottomSheet, { talk: item, speakers: getSpeakers(item) }));
+  }, [activeIndex, filtered, viewMode, speakers]);
 
   useEffect(() => {
     if (viewMode !== 'cards') {
@@ -178,12 +179,12 @@ function App() {
                   key: t.id,
                   onClick: () => {},
                 },
-                e(Card, { talk: t, speakers: t.speakers })
+                e(Card, { talk: t, speakers: getSpeakers(t) })
               )
             )
             )
         )
-      : e(TalkList, { items: filtered })
+      : e(TalkList, { items: filtered, speakers })
         );
 }
 

--- a/frontend/components/TalkList.js
+++ b/frontend/components/TalkList.js
@@ -9,7 +9,7 @@ const formatDate = d => {
   return `${dd}/${mm}/${yy}`;
 };
 
-export function TalkList({ items }) {
+export function TalkList({ items, speakers = [] }) {
   return e(
     'ul',
     { className: 'talk-list' },
@@ -18,17 +18,17 @@ export function TalkList({ items }) {
         t.status === 'past'
           ? e('a', { href: t.recordingLink, target: '_blank' }, 'Запись')
           : e('a', { href: t.registrationLink, target: '_blank' }, 'Регистрация');
+      const speakerNames = speakers
+        .filter(s => (t.speakerIds || []).includes(s.id))
+        .map(s => s.name)
+        .join(', ');
       return e(
         'li',
         { key: t.id },
         e(
           'div',
           null,
-          e(
-            'span',
-            { className: 'list-speaker' },
-            t.speakers.map(s => s.name).join(', ')
-          ),
+          e('span', { className: 'list-speaker' }, speakerNames),
           ' — ',
           e('span', { className: 'list-title' }, t.title)
         ),


### PR DESCRIPTION
## Summary
- derive talk speakers using speakerIds at render time
- compute speaker names for TalkList items from speakerIds

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899dbf1214083288f3cb20d75422f3e