### PR TITLE
Track unique speakers in stats calculations

### DIFF
--- a/frontend/stats.js
+++ b/frontend/stats.js
@@ -21,6 +21,7 @@ async function loadData() {
 function renderCharts(speakers, talks) {
   const talkCount = {};
   const speakerSets = {};
+  const allSpeakers = new Set();
   DIRECTIONS.forEach(d => {
     talkCount[d] = 0;
     speakerSets[d] = new Set();
@@ -29,11 +30,15 @@ function renderCharts(speakers, talks) {
   talks.forEach(t => {
     if (talkCount[t.direction] !== undefined) {
       talkCount[t.direction]++;
-      (t.speakerIds || []).forEach(id => speakerSets[t.direction].add(id));
+      (t.speakerIds || []).forEach(id => {
+        speakerSets[t.direction].add(id);
+        allSpeakers.add(id);
+      });
     }
   });
 
-  const activeSpeakers = DIRECTIONS.map(d => speakerSets[d].size);
+  const activeSpeakers = allSpeakers.size;
+  const speakerCounts = DIRECTIONS.map(d => speakerSets[d].size);
 
   const ctx1 = document.getElementById('talks-chart').getContext('2d');
   new Chart(ctx1, {
@@ -58,7 +63,7 @@ function renderCharts(speakers, talks) {
     data: {
       labels: DIRECTIONS,
       datasets: [{
-        data: activeSpeakers,
+        data: speakerCounts,
         backgroundColor: DIRECTIONS.map(d => ACCENTS[d] || '#ccc')
       }]
     },


### PR DESCRIPTION
## Summary
- Aggregate speaker IDs per direction and across all talks
- Derive total unique speaker count from all talks while maintaining per-direction stats

## Testing
- `node --check frontend/stats.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6899dee069b883288c724d15af401c6e