### PR TITLE
feat: use multiselect dropdown for talk speakers

### DIFF
--- a/frontend/components/forms.js
+++ b/frontend/components/forms.js
@@ -123,25 +123,17 @@ export function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
       null,
       e('label', null, 'Спикеры'),
       e(
-        'div',
-        null,
+        'select',
+        {
+          multiple: true,
+          value: speakerIds,
+          onChange: ev =>
+            setSpeakerIds(
+              Array.from(ev.target.selectedOptions, opt => opt.value)
+            ),
+        },
         speakers.map(s =>
-          e(
-            'label',
-            { key: s.id },
-            e('input', {
-              type: 'checkbox',
-              checked: speakerIds.includes(s.id),
-              onChange: ev => {
-                if (ev.target.checked) {
-                  setSpeakerIds([...speakerIds, s.id]);
-                } else {
-                  setSpeakerIds(speakerIds.filter(id => id !== s.id));
-                }
-              },
-            }),
-            s.name
-          )
+          e('option', { key: s.id, value: s.id }, s.name)
         )
       )
     ),


### PR DESCRIPTION
## Summary
- replace checkbox list with multi-select dropdown for choosing speakers in talk form

## Testing
- `node --check frontend/components/forms.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689a068fc5088328b85ddd3320dc581a