### PR TITLE
feat: redesign talks page

### DIFF
--- a/frontend/components/BottomSheet.js
+++ b/frontend/components/BottomSheet.js
@@ -47,7 +47,7 @@ export function BottomSheet({ talk, speakers = [] }) {
   };
 
   const link =
-    talk.status === 'past'
+    new Date(talk.date) < new Date()
       ? e('a', { href: talk.recordingLink, target: '_blank' }, 'Запись')
       : e('a', { href: talk.registrationLink, target: '_blank' }, 'Регистрация');
 
@@ -58,6 +58,8 @@ export function BottomSheet({ talk, speakers = [] }) {
       style: { borderTop: `8px solid ${accent}` },
       onPointerDown: handleStart,
       onTouchStart: handleStart,
+      role: 'dialog',
+      'aria-modal': true,
     },
     e('div', {
       className: `handle${expanded ? ' arrow-down' : ''}`,
@@ -79,8 +81,21 @@ export function BottomSheet({ talk, speakers = [] }) {
         )
       ),
       e('div', null, talk.description),
+      speakers.length > 0 &&
+        e(
+          'div',
+          { className: 'sheet-bio' },
+          speakers.map((s, idx) =>
+            e(
+              'p',
+              { key: s.id || idx },
+              e('strong', null, s.name + ': '),
+              s.description
+            )
+          )
+        ),
       e('div', { className: 'sheet-event' }, talk.eventName),
       link
-    ),
+    )
   );
 }

--- a/frontend/components/FilterPanel.js
+++ b/frontend/components/FilterPanel.js
@@ -1,0 +1,69 @@
+import { DIRECTIONS } from '../directions.js';
+const e = React.createElement;
+
+export function FilterPanel({ filters, onChange, visible }) {
+  const { direction, status, query, speaker, from, to } = filters;
+  const set = (key, value) => onChange({ ...filters, [key]: value });
+  const reset = () =>
+    onChange({ direction: 'all', status: 'all', query: '', speaker: '', from: '', to: '' });
+
+  return e(
+    'section',
+    {
+      className: `filter-panel${visible ? ' show' : ''}`,
+      'aria-hidden': !visible,
+    },
+    e('input', {
+      type: 'text',
+      placeholder: 'Название доклада',
+      value: query,
+      onChange: ev => set('query', ev.target.value),
+      'aria-label': 'Поиск по названию',
+    }),
+    e('input', {
+      type: 'text',
+      placeholder: 'Спикер',
+      value: speaker,
+      onChange: ev => set('speaker', ev.target.value),
+      'aria-label': 'Поиск по спикеру',
+    }),
+    e(
+      'select',
+      {
+        value: direction,
+        onChange: ev => set('direction', ev.target.value),
+        'aria-label': 'Направление',
+      },
+      e('option', { value: 'all' }, 'Все направления'),
+      DIRECTIONS.map(d => e('option', { key: d, value: d }, d))
+    ),
+    e(
+      'select',
+      {
+        value: status,
+        onChange: ev => set('status', ev.target.value),
+        'aria-label': 'Статус',
+      },
+      e('option', { value: 'all' }, 'Все статусы'),
+      e('option', { value: 'upcoming' }, 'Будущие'),
+      e('option', { value: 'past' }, 'Прошедшие')
+    ),
+    e('input', {
+      type: 'date',
+      value: from,
+      onChange: ev => set('from', ev.target.value),
+      'aria-label': 'Дата от',
+    }),
+    e('input', {
+      type: 'date',
+      value: to,
+      onChange: ev => set('to', ev.target.value),
+      'aria-label': 'Дата до',
+    }),
+    e(
+      'button',
+      { onClick: reset, 'aria-label': 'Сбросить фильтры' },
+      'Сбросить'
+    )
+  );
+}

--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -1,0 +1,34 @@
+const e = React.createElement;
+
+export function Header({ onToggleFilters, filtersOpen, viewMode, onViewChange }) {
+  return e(
+    'header',
+    { className: 'main-header' },
+    e('h1', null, 'Доклады'),
+    e(
+      'button',
+      {
+        onClick: onToggleFilters,
+        'aria-pressed': filtersOpen,
+        'aria-label': 'Показать фильтры',
+      },
+      'Фильтры'
+    ),
+    e(
+      'div',
+      { className: 'view-switch' },
+      e('span', null, viewMode === 'list' ? 'Список' : 'Карточки'),
+      e(
+        'label',
+        { className: 'switch' },
+        e('input', {
+          type: 'checkbox',
+          checked: viewMode === 'list',
+          onChange: () => onViewChange(viewMode === 'list' ? 'cards' : 'list'),
+          'aria-label': 'Переключить вид',
+        }),
+        e('span', { className: 'slider' })
+      )
+    )
+  );
+}

--- a/frontend/components/NavigationBar.js
+++ b/frontend/components/NavigationBar.js
@@ -1,0 +1,35 @@
+const e = React.createElement;
+
+export function NavigationBar() {
+  const isAdmin = window.__IS_ADMIN__;
+  return e(
+    'nav',
+    { className: 'bottom-nav', 'aria-label': 'Основная навигация' },
+    e(
+      'a',
+      { href: '/', className: 'nav-item active', 'aria-label': 'Доклады' },
+      e('span', { className: 'icon', 'aria-hidden': true }, '🎤'),
+      e('span', { className: 'label' }, 'Доклады')
+    ),
+    isAdmin &&
+      e(
+        'a',
+        { href: '/stats', className: 'nav-item', 'aria-label': 'Статистика' },
+        e('span', { className: 'icon', 'aria-hidden': true }, '📊'),
+        e('span', { className: 'label' }, 'Статистика')
+      ),
+    isAdmin &&
+      e(
+        'a',
+        { href: '/admin', className: 'nav-item', 'aria-label': 'Настройки' },
+        e('span', { className: 'icon', 'aria-hidden': true }, '⚙️'),
+        e('span', { className: 'label' }, 'Настройки')
+      ),
+    e(
+      'a',
+      { href: '/profile', className: 'nav-item', 'aria-label': 'Профиль' },
+      e('span', { className: 'icon', 'aria-hidden': true }, '👤'),
+      e('span', { className: 'label' }, 'Профиль')
+    )
+  );
+}

--- a/frontend/components/TalkCard.js
+++ b/frontend/components/TalkCard.js
@@ -1,0 +1,62 @@
+import { ACCENTS } from '../constants.js';
+const e = React.createElement;
+
+const formatDate = d => {
+  const date = new Date(d);
+  if (isNaN(date)) return d;
+  const dd = String(date.getDate()).padStart(2, '0');
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const yyyy = date.getFullYear();
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mi = String(date.getMinutes()).padStart(2, '0');
+  return `${dd}.${mm}.${yyyy} ${hh}:${mi}`;
+};
+
+export function TalkCard({ talk, speakers = [], onSelect }) {
+  const isPast = new Date(talk.date) < new Date();
+  const accent = ACCENTS[talk.direction] || '#03a9f4';
+  const actionLabel = isPast ? 'Запись' : 'Регистрация';
+  const actionLink = isPast ? talk.recordingLink : talk.registrationLink;
+
+  return e(
+    'article',
+    {
+      className: `talk-card ${isPast ? 'past' : 'upcoming'}`,
+      onClick: () => onSelect && onSelect(talk),
+      tabIndex: 0,
+      role: 'button',
+      'aria-label': `Доклад ${talk.title}`,
+      style: { borderLeft: `4px solid ${accent}` },
+    },
+    e(
+      'div',
+      { className: 'speakers' },
+      speakers.map((s, idx) =>
+        e(
+          'span',
+          { key: s.id || idx },
+          e('strong', null, s.name),
+          idx < speakers.length - 1 ? ', ' : ''
+        )
+      )
+    ),
+    e('h3', { className: 'talk-title' }, talk.title),
+    e('time', { dateTime: talk.date }, formatDate(talk.date)),
+    e('div', { className: 'talk-event' }, talk.eventName),
+    actionLink &&
+      e(
+        'div',
+        { className: 'action' },
+        e(
+          'a',
+          {
+            href: actionLink,
+            target: '_blank',
+            onClick: ev => ev.stopPropagation(),
+            'aria-label': actionLabel,
+          },
+          actionLabel
+        )
+      )
+  );
+}

--- a/frontend/hooks/useTalkData.js
+++ b/frontend/hooks/useTalkData.js
@@ -1,0 +1,72 @@
+const e = React.createElement;
+const { useState, useEffect, useMemo } = React;
+
+export function useTalkData(filters) {
+  const [talks, setTalks] = useState([]);
+  const [speakers, setSpeakers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    const load = async () => {
+      try {
+        const [speakersRes, talksRes] = await Promise.all([
+          fetch('/api/speakers'),
+          fetch('/api/talks'),
+        ]);
+        if (!speakersRes.ok || !talksRes.ok) throw new Error('Fetch error');
+        const [speakersData, talksData] = await Promise.all([
+          speakersRes.json(),
+          talksRes.json(),
+        ]);
+        if (!active) return;
+        setSpeakers(speakersData);
+        setTalks(talksData);
+      } catch (err) {
+        if (active) setError('Не удалось загрузить данные');
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const filtered = useMemo(() => {
+    const {
+      direction = 'all',
+      status = 'all',
+      query = '',
+      speaker = '',
+      from = '',
+      to = '',
+    } = filters || {};
+    let list = talks.slice();
+    if (direction !== 'all') list = list.filter(t => t.direction === direction);
+    if (status !== 'all') list = list.filter(t => t.status === status);
+    if (query)
+      list = list.filter(t =>
+        (t.title || '').toLowerCase().includes(query.toLowerCase())
+      );
+    if (speaker)
+      list = list.filter(t => {
+        const names = speakers
+          .filter(s => (t.speakerIds || []).includes(s.id))
+          .map(s => s.name.toLowerCase());
+        return names.some(n => n.includes(speaker.toLowerCase()));
+      });
+    if (from) list = list.filter(t => new Date(t.date) >= new Date(from));
+    if (to) list = list.filter(t => new Date(t.date) <= new Date(to));
+    list.sort((a, b) => new Date(a.date) - new Date(b.date));
+    return list;
+  }, [talks, speakers, filters]);
+
+  const now = new Date();
+  const upcoming = filtered.filter(t => new Date(t.date) >= now);
+  const past = filtered.filter(t => new Date(t.date) < now);
+
+  return { upcoming, past, speakers, loading, error };
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,12 +17,7 @@
 <body>
   <div id="root"></div>
   <div id="bottom-sheet-root"></div>
-  <nav class="bottom-nav">
-    <a href="/" class="active" title="Выступления">🎤</a>
-    <a href="/stats" id="stats-link" title="Статистика">📊</a>
-    <a href="/admin" id="admin-link" title="Админка">⚙️</a>
-    <a href="/profile" title="Личный кабинет">👤</a>
-  </nav>
+  <div id="nav-root"></div>
   <script src="/config.js"></script>
   <script>
     (function() {
@@ -34,13 +29,10 @@
         document.cookie = 'username=' + encodeURIComponent(user.username) + ';path=/';
       }
       const isAdmin = user && cfg.admins.includes(user.username);
-      if (cfg.mode !== 'debug' && !isAdmin) {
-        document.getElementById('admin-link')?.remove();
-        document.getElementById('stats-link')?.remove();
-      }
+      window.__IS_ADMIN__ = cfg.mode === 'debug' || isAdmin;
       const tryExpand = () => {
-          tg.ready();
-          tg.expand();
+        tg.ready();
+        tg.expand();
       };
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -310,48 +310,12 @@ form select {
   display: inline-block;
   margin-top: 8px;
 }
-.bottom-nav {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  display: flex;
-  justify-content: space-around;
-  background: rgba(0,0,0,0.6);
-  backdrop-filter: blur(10px);
-  border-top: 1px solid rgba(255,255,255,0.3);
-  padding: 10px 0;
-  padding-bottom: calc(10px + env(safe-area-inset-bottom));
-  z-index: 30;
-}
-
-.bottom-nav.disabled {
-  pointer-events: none;
-}
-
-.bottom-nav a {
-  text-decoration: none;
-  font-size: 24px;
-  color: #fff;
-}
-
-.bottom-nav a.active {
-  color: #00e5ff;
-}
 
 .error {
   color: red;
   margin-bottom: 10px;
 }
 
-.view-switch {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  z-index: 10;
-  display: flex;
-  align-items: center;
-  gap: 6px;
 }
 
 .switch {
@@ -464,4 +428,173 @@ form select {
   border-radius: 8px;
   padding: 10px;
   width: 100%;
+}
+
+/* ===== New styles for updated talk list page ===== */
+body {
+  background: var(--tg-bg-color, #ffffff);
+  color: var(--tg-text-color, #000000);
+}
+
+.main-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: calc(env(safe-area-inset-top) + 8px) 16px 8px;
+  background: var(--tg-secondary-bg-color, rgba(0,0,0,0.1));
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.main-header h1 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.view-switch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.filter-panel {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: var(--tg-secondary-bg-color, #fff);
+  color: var(--tg-text-color, #000);
+  padding: 16px;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.filter-panel.show {
+  transform: translateY(0);
+}
+
+.filter-panel input,
+.filter-panel select {
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 16px;
+}
+
+.active-filters span {
+  background: var(--tg-secondary-bg-color, rgba(0,0,0,0.1));
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+}
+
+.talk-list,
+.card-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.card-grid {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.talk-card {
+  background: var(--tg-secondary-bg-color, rgba(0,0,0,0.05));
+  padding: 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.talk-card.past {
+  opacity: 0.7;
+}
+
+.talk-card .speakers strong {
+  font-weight: 700;
+}
+
+.talk-card .action {
+  margin-top: 8px;
+}
+
+.talk-card .action a {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 4px;
+  background: var(--tg-button-color, #00e5ff);
+  color: var(--tg-button-text-color, #000);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.talk-card.past .action a {
+  background: none;
+  color: var(--tg-link-color, #00e5ff);
+  text-decoration: underline;
+}
+
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  background: var(--tg-secondary-bg-color, rgba(0,0,0,0.1));
+  padding-bottom: env(safe-area-inset-bottom);
+  height: var(--bottom-nav-height);
+}
+
+.bottom-nav a {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--tg-text-color, #000);
+  text-decoration: none;
+  font-size: 0.8rem;
+}
+
+.bottom-nav .icon {
+  font-size: 1.2rem;
+}
+
+.loader {
+  margin: 40px auto;
+  border: 4px solid var(--tg-secondary-bg-color, #ccc);
+  border-top-color: var(--tg-button-color, #00e5ff);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+.bottom-nav.disabled {
+  pointer-events: none;
+  opacity: 0.4;
 }


### PR DESCRIPTION
## Summary
- refactor talk list with new TalkCard, Header and filter panel
- support search, direction/status/date filters and dynamic theme colors
- add bottom navigation with labels and speaker bios in the bottom sheet

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b15c285dc8328857613c9f9e2f50e