### PR TITLE
Fix scrolling on talks page

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -61,7 +61,7 @@ function App() {
 
   return e(
     'div',
-    null,
+    { className: 'talks-page' },
     e(Header, {
       onToggleFilters: () => setShowFilters(!showFilters),
       filtersOpen: showFilters,
@@ -81,7 +81,7 @@ function App() {
       ? e('div', { className: 'error' }, error)
       : e(
           'main',
-          null,
+          { className: 'talks-container' },
           e(
             'section',
             null,

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -28,7 +28,7 @@ body {
   background: linear-gradient(180deg, #cf00ff 0%, #3100ff 100%);
   background-attachment: fixed;
   overflow-x: hidden;
-  overflow-y: hidden;
+  overflow-y: auto;
   color: #fff;
 }
 
@@ -75,6 +75,18 @@ html.admin-page {
   -webkit-overflow-scrolling: touch;
   /* space for bottom nav, bottom sheet and safe areas */
   padding-bottom: calc(150px + env(safe-area-inset-bottom));
+}
+
+.talks-page {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.talks-container {
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .card {


### PR DESCRIPTION
## Summary
- Allow body to scroll and add dedicated container for talk list
- Introduce talks-page and talks-container classes with flexible heights

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b20ef99088328aad5ece77c17d35a