### PR TITLE
Enable fullscreen mode and disable vertical swipes in Telegram WebApp

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -43,7 +43,10 @@
       }
       const tryExpand = () => {
           tg.ready();
-          tg.expand();
+          tg.expand?.();
+          tg.requestFullscreen?.();
+          tg.disableVerticalSwipes?.();
+          tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
       };
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -22,6 +22,10 @@ function AdminApp() {
     const load = async () => {
         const tg = window.Telegram?.WebApp;
         tg?.ready();
+        tg?.expand?.();
+        tg?.requestFullscreen?.();
+        tg?.disableVerticalSwipes?.();
+        tg?.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
         const user = tg?.initDataUnsafe?.user;
         if (user) {
           setUsername(user.username);
@@ -30,10 +34,6 @@ function AdminApp() {
           setAuthorized(true);
         } else if (user) {
           setAuthorized(ALLOWED_USERS.includes(user.username));
-        }
-        if (tg && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
-          tg.ready();
-          tg.expand();
         }
       try {
         const [speakersRes, talksRes] = await Promise.all([

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -150,12 +150,28 @@ function App() {
   );
 }
 
-// Expand the Telegram WebApp on mobile if running inside Telegram
+// Раскрываем мини-приложение, переводим его в полноэкранный режим и отключаем вертикальные свайпы
 const tryExpand = () => {
-  const tg = window.Telegram.WebApp;
+  const tg = window.Telegram?.WebApp;
+  if (!tg) return;
   tg.ready();
-  tg.expand();
+  // Разворачиваем BottomSheet на мобильных устройствах
+  tg.expand?.();
+  // Запрашиваем полноэкранный режим (Bot API 8.0+)
+  if (typeof tg.requestFullscreen === 'function') {
+    tg.requestFullscreen();
+    // Настраиваем цвет заголовка для контрастности (при необходимости)
+    tg.setHeaderColor?.('#FFFFFF');
+  }
+  // Отключаем вертикальные свайпы, чтобы приложение не сворачивалось при прокрутке
+  if (typeof tg.disableVerticalSwipes === 'function') {
+    tg.disableVerticalSwipes();
+  } else if (typeof tg.postEvent === 'function') {
+    // Новый вариант API — web_app_setup_swipe_behavior
+    tg.postEvent('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
+  }
 };
+// Инициализируем при загрузке
 if (document.readyState === 'loading') {
   window.addEventListener('DOMContentLoaded', tryExpand);
 } else {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -32,7 +32,10 @@
       window.__IS_ADMIN__ = cfg.mode === 'debug' || isAdmin;
       const tryExpand = () => {
         tg.ready();
-        tg.expand();
+        tg.expand?.();
+        tg.requestFullscreen?.();
+        tg.disableVerticalSwipes?.();
+        tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
       };
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -35,7 +35,10 @@
       }
       const tryExpand = () => {
           tg.ready();
-          tg.expand();
+          tg.expand?.();
+          tg.requestFullscreen?.();
+          tg.disableVerticalSwipes?.();
+          tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
       };
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -7,9 +7,10 @@ function ProfileApp() {
     const tg = window.Telegram?.WebApp;
     tg?.ready();
     setUser(tg?.initDataUnsafe?.user || null);
-    if (tg && (tg.platform === 'android' || tg.platform === 'ios') && !tg.isExpanded) {
-      tg.expand();
-    }
+    tg?.expand?.();
+    tg?.requestFullscreen?.();
+    tg?.disableVerticalSwipes?.();
+    tg?.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
   }, []);
 
   if (!user) {

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -45,7 +45,10 @@
       }
       const tryExpand = () => {
           tg.ready();
-          tg.expand();
+          tg.expand?.();
+          tg.requestFullscreen?.();
+          tg.disableVerticalSwipes?.();
+          tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
       };
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);


### PR DESCRIPTION
## Summary
- Expand WebApp in fullscreen and disable vertical swipes in main app
- Apply fullscreen/swipe configuration across index, admin, profile, and stats pages
- Ensure admin and profile React components request fullscreen and block vertical swipes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b24feebac8328b666e11bc55be092