### PR TITLE
Handle Telegram safe-area offsets across pages

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -31,7 +31,7 @@
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   /* account for safe areas and fixed bottom navigation */
-  padding-bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom));
+  padding-bottom: calc(var(--bottom-nav-height) + var(--safe-area-bottom));
 }
 
 /* Forms and lists layout */

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -13,7 +13,7 @@
   <!-- Telegram WebApp JS -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
-<body class="admin-page">
+<body class="admin-page page">
   <header>
     <h1>Панель администратора</h1>
   </header>
@@ -41,13 +41,30 @@
         document.querySelector('main.admin-content').innerHTML = 'Доступ запрещён';
         return;
       }
+      function updateSafeArea() {
+        const safe = tg?.safeAreaInset;
+        const contentSafe = tg?.contentSafeAreaInset;
+        if (safe) {
+          document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
+          document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
+        }
+        if (contentSafe) {
+          document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
+          document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
+        }
+      }
       const tryExpand = () => {
           tg.ready();
           tg.expand?.();
           tg.requestFullscreen?.();
           tg.disableVerticalSwipes?.();
           tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
+          tg.requestSafeArea?.();
+          tg.requestContentSafeArea?.();
+          updateSafeArea();
       };
+      tg?.onEvent?.('safeAreaChanged', updateSafeArea);
+      tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);
       } else {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10,6 +10,20 @@ const { useState, useEffect } = React;
 
 const sheetRoot = ReactDOM.createRoot(document.getElementById('bottom-sheet-root'));
 const navRoot = ReactDOM.createRoot(document.getElementById('nav-root'));
+const tg = window.Telegram?.WebApp;
+
+function updateSafeArea() {
+  const safe = tg?.safeAreaInset;
+  const contentSafe = tg?.contentSafeAreaInset;
+  if (safe) {
+    document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
+    document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
+  }
+  if (contentSafe) {
+    document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
+    document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
+  }
+}
 
 function App() {
   const [filters, setFilters] = useState({
@@ -152,7 +166,6 @@ function App() {
 
 // Раскрываем мини-приложение, переводим его в полноэкранный режим и отключаем вертикальные свайпы
 const tryExpand = () => {
-  const tg = window.Telegram?.WebApp;
   if (!tg) return;
   tg.ready();
   // Разворачиваем BottomSheet на мобильных устройствах
@@ -170,6 +183,9 @@ const tryExpand = () => {
     // Новый вариант API — web_app_setup_swipe_behavior
     tg.postEvent('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
   }
+  tg.requestSafeArea?.();
+  tg.requestContentSafeArea?.();
+  updateSafeArea();
 };
 // Инициализируем при загрузке
 if (document.readyState === 'loading') {
@@ -177,5 +193,7 @@ if (document.readyState === 'loading') {
 } else {
   tryExpand();
 }
+tg?.onEvent?.('safeAreaChanged', updateSafeArea);
+tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
 
 ReactDOM.createRoot(document.getElementById('root')).render(e(App));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,7 +14,7 @@
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
 </head>
-<body>
+<body class="page">
   <div id="root"></div>
   <div id="bottom-sheet-root"></div>
   <div id="nav-root"></div>
@@ -30,13 +30,30 @@
       }
       const isAdmin = user && cfg.admins.includes(user.username);
       window.__IS_ADMIN__ = cfg.mode === 'debug' || isAdmin;
+      function updateSafeArea() {
+        const safe = tg?.safeAreaInset;
+        const contentSafe = tg?.contentSafeAreaInset;
+        if (safe) {
+          document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
+          document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
+        }
+        if (contentSafe) {
+          document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
+          document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
+        }
+      }
       const tryExpand = () => {
         tg.ready();
         tg.expand?.();
         tg.requestFullscreen?.();
         tg.disableVerticalSwipes?.();
         tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
+        tg.requestSafeArea?.();
+        tg.requestContentSafeArea?.();
+        updateSafeArea();
       };
+      tg?.onEvent?.('safeAreaChanged', updateSafeArea);
+      tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);
       } else {

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -10,7 +10,7 @@
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
-<body>
+<body class="page">
   <div id="profile-root"></div>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
@@ -33,13 +33,30 @@
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }
+      function updateSafeArea() {
+        const safe = tg?.safeAreaInset;
+        const contentSafe = tg?.contentSafeAreaInset;
+        if (safe) {
+          document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
+          document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
+        }
+        if (contentSafe) {
+          document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
+          document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
+        }
+      }
       const tryExpand = () => {
           tg.ready();
           tg.expand?.();
           tg.requestFullscreen?.();
           tg.disableVerticalSwipes?.();
           tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
+          tg.requestSafeArea?.();
+          tg.requestContentSafeArea?.();
+          updateSafeArea();
       };
+      tg?.onEvent?.('safeAreaChanged', updateSafeArea);
+      tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);
       } else {

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -1,16 +1,34 @@
 const e = React.createElement;
 const { useEffect, useState } = React;
+const tg = window.Telegram?.WebApp;
+
+function updateSafeArea() {
+  const safe = tg?.safeAreaInset;
+  const contentSafe = tg?.contentSafeAreaInset;
+  if (safe) {
+    document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
+    document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
+  }
+  if (contentSafe) {
+    document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
+    document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
+  }
+}
 
 function ProfileApp() {
   const [user, setUser] = useState(null);
   useEffect(() => {
-    const tg = window.Telegram?.WebApp;
     tg?.ready();
     setUser(tg?.initDataUnsafe?.user || null);
     tg?.expand?.();
     tg?.requestFullscreen?.();
     tg?.disableVerticalSwipes?.();
     tg?.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
+    tg?.requestSafeArea?.();
+    tg?.requestContentSafeArea?.();
+    updateSafeArea();
+    tg?.onEvent?.('safeAreaChanged', updateSafeArea);
+    tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
   }, []);
 
   if (!user) {

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -11,7 +11,7 @@
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
-<body class="stats-page">
+<body class="stats-page page">
   <div class="stats-wrapper">
     <div class="chart-block">
       <h3 class="chart-title">Доклады по направлениям</h3>
@@ -43,13 +43,30 @@
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }
+      function updateSafeArea() {
+        const safe = tg?.safeAreaInset;
+        const contentSafe = tg?.contentSafeAreaInset;
+        if (safe) {
+          document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
+          document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
+        }
+        if (contentSafe) {
+          document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
+          document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
+        }
+      }
       const tryExpand = () => {
           tg.ready();
           tg.expand?.();
           tg.requestFullscreen?.();
           tg.disableVerticalSwipes?.();
           tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
+          tg.requestSafeArea?.();
+          tg.requestContentSafeArea?.();
+          updateSafeArea();
       };
+      tg?.onEvent?.('safeAreaChanged', updateSafeArea);
+      tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);
       } else {

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,4 +1,8 @@
 :root {
+  --safe-area-top: 0px;
+  --safe-area-bottom: 0px;
+  --content-safe-area-top: 0px;
+  --content-safe-area-bottom: 0px;
   /* Lift speaker images higher on the screen */
   --speaker-top: 20px;
   /* Slightly reduce the height so prev/next speakers remain visible */
@@ -21,6 +25,12 @@ html, body {
   padding: 0;
   /* Prevent pull-down gesture from closing Telegram browser */
   overscroll-behavior-y: contain;
+}
+
+/* Provide default safe area offsets for page containers */
+.page {
+  padding-top: calc(var(--content-safe-area-top) + 12px);
+  padding-bottom: var(--content-safe-area-bottom);
 }
 
 body {
@@ -61,7 +71,7 @@ html.admin-page {
   -webkit-overflow-scrolling: touch;
   /* reserve space for bottom navigation and safe areas */
   padding-bottom: calc(
-    var(--bottom-nav-height) + env(safe-area-inset-bottom)
+    var(--bottom-nav-height) + var(--safe-area-bottom)
   );
 }
 
@@ -74,7 +84,7 @@ html.admin-page {
   overscroll-behavior-y: contain;
   -webkit-overflow-scrolling: touch;
   /* space for bottom nav, bottom sheet and safe areas */
-  padding-bottom: calc(150px + env(safe-area-inset-bottom));
+  padding-bottom: calc(150px + var(--safe-area-bottom));
 }
 
 .talks-page {
@@ -241,7 +251,7 @@ form select {
 .bottom-sheet {
   position: fixed;
   top: calc(var(--speaker-top) + var(--speaker-height));
-  bottom: calc(var(--bottom-nav-height) + env(safe-area-inset-bottom));
+  bottom: calc(var(--bottom-nav-height) + var(--safe-area-bottom));
   left: 0;
   right: 0;
   background: #111;
@@ -252,7 +262,7 @@ form select {
   display: flex;
   flex-direction: column;
   max-height: calc(
-    100vh - var(--speaker-top) - var(--speaker-height) - var(--bottom-nav-height) - env(safe-area-inset-bottom)
+    100vh - var(--speaker-top) - var(--speaker-height) - var(--bottom-nav-height) - var(--safe-area-bottom)
   );
   min-height: 40vh;
   transition: top 0.3s ease, bottom 0.3s ease, border-radius 0.3s ease;
@@ -263,7 +273,7 @@ form select {
   top: 20vh;
   bottom: 0;
   max-height: none;
-  height: calc(80vh - env(safe-area-inset-bottom));
+  height: calc(80vh - var(--safe-area-bottom));
   border-radius: 20px 20px 0 0;
 }
 
@@ -271,18 +281,18 @@ form select {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   max-height: calc(
-    100vh - var(--sheet-header-height) - var(--bottom-nav-height) - env(safe-area-inset-bottom)
+    100vh - var(--sheet-header-height) - var(--bottom-nav-height) - var(--safe-area-bottom)
   );
   /* leave room for the fixed action button */
   padding-bottom: calc(
-    var(--bottom-nav-height) + 80px + env(safe-area-inset-bottom)
+    var(--bottom-nav-height) + 80px + var(--safe-area-bottom)
   );
   flex: 1;
 }
 
 .bottom-sheet.expanded .sheet-content {
   max-height: none;
-  padding-bottom: calc(80px + env(safe-area-inset-bottom));
+  padding-bottom: calc(80px + var(--safe-area-bottom));
 }
 
 .bottom-sheet .handle {
@@ -381,7 +391,7 @@ form select {
   margin-top: 60px;
   /* avoid overlap with the fixed bottom navigation */
   padding-bottom: calc(
-    var(--bottom-nav-height) + env(safe-area-inset-bottom)
+    var(--bottom-nav-height) + var(--safe-area-bottom)
   );
 }
 
@@ -421,7 +431,7 @@ form select {
   /* allow slight pull-down to avoid Telegram browser minimization */
   min-height: calc(100% + 20px);
   /* leave space for bottom nav */
-  padding-bottom: calc(20px + var(--bottom-nav-height) + env(safe-area-inset-bottom));
+  padding-bottom: calc(20px + var(--bottom-nav-height) + var(--safe-area-bottom));
 }
 
 .chart-block {
@@ -452,7 +462,7 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: calc(env(safe-area-inset-top) + 8px) 16px 8px;
+  padding: calc(var(--safe-area-top) + 8px) 16px 8px;
   background: var(--tg-secondary-bg-color, rgba(0,0,0,0.1));
   position: sticky;
   top: 0;
@@ -572,7 +582,7 @@ body {
   display: flex;
   justify-content: space-around;
   background: var(--tg-secondary-bg-color, rgba(0,0,0,0.1));
-  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: var(--safe-area-bottom);
   height: var(--bottom-nav-height);
 }
 


### PR DESCRIPTION
## Summary
- add CSS variables for safe-area and apply padding via `.page`
- update app initialization to request safe areas from Telegram and react to changes
- initialize safe-area handling in profile and page scripts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b405ce2648328b497cbb220e146f7