### PR TITLE
Remove view toggle from main page

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -35,7 +35,6 @@ function App() {
     to: '',
   });
   const [showFilters, setShowFilters] = useState(false);
-  const [viewMode, setViewMode] = useState('list');
   const [selectedTalk, setSelectedTalk] = useState(null);
 
   const { upcoming, past, speakers, loading, error } = useTalkData(filters);
@@ -79,8 +78,6 @@ function App() {
     e(Header, {
       onToggleFilters: () => setShowFilters(!showFilters),
       filtersOpen: showFilters,
-      viewMode,
-      onViewChange: setViewMode,
     }),
     e(FilterPanel, { filters, onChange: setFilters, visible: showFilters }),
     activeFilters.length > 0 &&
@@ -102,22 +99,9 @@ function App() {
             e('h2', null, 'Будущие'),
             upcoming.length === 0
               ? e('p', null, 'Нет докладов')
-              : viewMode === 'list'
-              ? e(
-                  'div',
-                  { className: 'talk-list' },
-                  upcoming.map(t =>
-                    e(TalkCard, {
-                      key: t.id,
-                      talk: t,
-                      speakers: getSpeakers(t),
-                      onSelect: setSelectedTalk,
-                    })
-                  )
-                )
               : e(
                   'div',
-                  { className: 'card-grid' },
+                  { className: 'talk-list' },
                   upcoming.map(t =>
                     e(TalkCard, {
                       key: t.id,
@@ -134,22 +118,9 @@ function App() {
             e('h2', null, 'Прошедшие'),
             past.length === 0
               ? e('p', null, 'Нет докладов')
-              : viewMode === 'list'
-              ? e(
-                  'div',
-                  { className: 'talk-list past' },
-                  past.map(t =>
-                    e(TalkCard, {
-                      key: t.id,
-                      talk: t,
-                      speakers: getSpeakers(t),
-                      onSelect: setSelectedTalk,
-                    })
-                  )
-                )
               : e(
                   'div',
-                  { className: 'card-grid past' },
+                  { className: 'talk-list past' },
                   past.map(t =>
                     e(TalkCard, {
                       key: t.id,

--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -1,6 +1,6 @@
 const e = React.createElement;
 
-export function Header({ onToggleFilters, filtersOpen, viewMode, onViewChange }) {
+export function Header({ onToggleFilters, filtersOpen }) {
   return e(
     'header',
     { className: 'main-header' },
@@ -13,22 +13,6 @@ export function Header({ onToggleFilters, filtersOpen, viewMode, onViewChange })
         'aria-label': 'Показать фильтры',
       },
       'Фильтры'
-    ),
-    e(
-      'div',
-      { className: 'view-switch' },
-      e('span', null, viewMode === 'list' ? 'Список' : 'Карточки'),
-      e(
-        'label',
-        { className: 'switch' },
-        e('input', {
-          type: 'checkbox',
-          checked: viewMode === 'list',
-          onChange: () => onViewChange(viewMode === 'list' ? 'cards' : 'list'),
-          'aria-label': 'Переключить вид',
-        }),
-        e('span', { className: 'slider' })
-      )
     )
   );
 }

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -340,50 +340,6 @@ form select {
 
 }
 
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 40px;
-  height: 20px;
-}
-
-.switch input {
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: #ccc;
-  transition: background-color 0.3s;
-  border-radius: 20px;
-}
-
-.slider:before {
-  position: absolute;
-  content: '';
-  height: 16px;
-  width: 16px;
-  left: 2px;
-  bottom: 2px;
-  background: #fff;
-  transition: transform 0.3s;
-  border-radius: 50%;
-}
-
-.switch input:checked + .slider {
-  background: #00e5ff;
-}
-
-.switch input:checked + .slider:before {
-  transform: translateX(20px);
-}
 
 .talk-list {
   list-style: none;
@@ -474,11 +430,6 @@ body {
   font-size: 1.2rem;
 }
 
-.view-switch {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
 
 .filter-panel {
   position: fixed;
@@ -521,19 +472,13 @@ body {
   font-size: 0.75rem;
 }
 
-.talk-list,
-.card-grid {
+.talk-list {
   display: flex;
   flex-direction: column;
   gap: 12px;
   list-style: none;
   padding: 0;
   margin: 0;
-}
-
-.card-grid {
-  flex-direction: row;
-  flex-wrap: wrap;
 }
 
 .talk-card {


### PR DESCRIPTION
## Summary
- drop view-mode toggle from header so only filters remain
- simplify main page to always render talks in list layout
- clean up obsolete toggle styles

## Testing
- `npm test` (fails: ENOENT package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b438c1fc48328be6c69b5e839abf3