### PR TITLE
feat(frontend): set default speaker photo and allow save without image

### DIFF
--- a/frontend/components/forms.js
+++ b/frontend/components/forms.js
@@ -6,7 +6,7 @@ const { useState } = React;
 export function SpeakerForm({ initial = {}, onSubmit, onCancel }) {
   const [name, setName] = useState(initial.name || '');
   const [description, setDescription] = useState(initial.description || '');
-  const [photoUrl, setPhotoUrl] = useState(initial.photoUrl || '');
+  const [photoUrl, setPhotoUrl] = useState(initial.photoUrl || '/default_icon.svg');
   const [tags, setTags] = useState(initial.tags || []);
   const [uploading, setUploading] = useState(false);
 
@@ -76,7 +76,7 @@ export function SpeakerForm({ initial = {}, onSubmit, onCancel }) {
         ? e('div', null, 'Загрузка фото...')
         : e('input', { type: 'file', onChange: ev => ev.target.files[0] && uploadFile(ev.target.files[0]) })
     ),
-    e('button', { type: 'submit', disabled: uploading || !photoUrl }, 'Сохранить'),
+    e('button', { type: 'submit', disabled: uploading }, 'Сохранить'),
     e('button', { type: 'button', onClick: onCancel }, 'Отмена')
   );
 }


### PR DESCRIPTION
## Summary
- default SpeakerForm photo URL to `/default_icon.svg`
- allow saving speaker without requiring a photo

## Testing
- `node --check frontend/components/forms.js`
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689d930e61c88328b4dc032d2200a8fd