### PR TITLE
Remove nav text labels to show icon-only links

### DIFF
--- a/frontend/components/NavigationBar.js
+++ b/frontend/components/NavigationBar.js
@@ -7,29 +7,45 @@ export function NavigationBar() {
     { className: 'bottom-nav', 'aria-label': 'Основная навигация' },
     e(
       'a',
-      { href: '/', className: 'nav-item active', 'aria-label': 'Доклады' },
-      e('span', { className: 'icon', 'aria-hidden': true }, '🎤'),
-      e('span', { className: 'label' }, 'Доклады')
+      {
+        href: '/',
+        className: 'nav-item active',
+        'aria-label': 'Доклады',
+        title: 'Доклады',
+      },
+      e('span', { className: 'icon', 'aria-hidden': true }, '🎤')
     ),
     isAdmin &&
       e(
         'a',
-        { href: '/stats', className: 'nav-item', 'aria-label': 'Статистика' },
-        e('span', { className: 'icon', 'aria-hidden': true }, '📊'),
-        e('span', { className: 'label' }, 'Статистика')
+        {
+          href: '/stats',
+          className: 'nav-item',
+          'aria-label': 'Статистика',
+          title: 'Статистика',
+        },
+        e('span', { className: 'icon', 'aria-hidden': true }, '📊')
       ),
     isAdmin &&
       e(
         'a',
-        { href: '/admin', className: 'nav-item', 'aria-label': 'Настройки' },
-        e('span', { className: 'icon', 'aria-hidden': true }, '⚙️'),
-        e('span', { className: 'label' }, 'Настройки')
+        {
+          href: '/admin',
+          className: 'nav-item',
+          'aria-label': 'Настройки',
+          title: 'Настройки',
+        },
+        e('span', { className: 'icon', 'aria-hidden': true }, '⚙️')
       ),
     e(
       'a',
-      { href: '/profile', className: 'nav-item', 'aria-label': 'Профиль' },
-      e('span', { className: 'icon', 'aria-hidden': true }, '👤'),
-      e('span', { className: 'label' }, 'Профиль')
+      {
+        href: '/profile',
+        className: 'nav-item',
+        'aria-label': 'Профиль',
+        title: 'Профиль',
+      },
+      e('span', { className: 'icon', 'aria-hidden': true }, '👤')
     )
   );
 }


### PR DESCRIPTION
## Summary
- drop text label spans from navigation links
- ensure each nav item retains accessible `aria-label` and `title` attributes

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d94d78298832887b50ce8c149d1ff