### PR TITLE
Use Choices to fetch speaker IDs on submit

### DIFF
--- a/frontend/components/forms.js
+++ b/frontend/components/forms.js
@@ -116,6 +116,7 @@ export function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
 
   const handleSubmit = ev => {
     ev.preventDefault();
+    const speakerIds = choicesRef.current.getValue(true);
     if (!speakerIds.length || !title.trim() || !eventName.trim() || !direction || !date) {
       alert('Заполните обязательные поля');
       return;


### PR DESCRIPTION
## Summary
- Retrieve selected speaker IDs from Choices instance during talk submission

## Testing
- `python -m pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_689d9a23d6308328a993ac2c0ab9cd57