### PR TITLE
Remove unused Swiper CDN references

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Admin</title>
-  <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
   <link rel="stylesheet" href="styles.css" />
   <link rel="stylesheet" href="admin.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Speakers Platform</title>
-  <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
   <link rel="stylesheet" href="styles.css" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
   <!-- React and dependencies from CDN -->
@@ -12,7 +11,6 @@
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <!-- Telegram WebApp JS to access Telegram features -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
-  <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
 </head>
 <body class="page">
   <div id="root"></div>


### PR DESCRIPTION
## Summary
- drop Swiper CDN `<link>` and `<script>` tags from `index.html` and `admin.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `MODE=debug python app.py` then `curl -I http://localhost:5000/`
- `MODE=debug python app.py` then `curl -I http://localhost:5000/admin`


------
https://chatgpt.com/codex/tasks/task_e_689da7f957448328a00bb9402e84e82e