### PR TITLE
fix: remove extra body scroll

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -38,7 +38,8 @@ body {
   background: linear-gradient(180deg, #cf00ff 0%, #3100ff 100%);
   background-attachment: fixed;
   overflow-x: hidden;
-  overflow-y: auto;
+  /* prevent double scroll; #root manages scrolling */
+  overflow-y: hidden;
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- prevent body from scrolling to avoid duplicate scrollbars

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dba025bbc83289167a6f74e1ccea8