### PR TITLE
Fix footer overlap on talks list

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -104,6 +104,8 @@ html.admin-page {
   height: calc(
     100% - var(--header-height) - var(--footer-height) - var(--tg-content-safe-area-inset-top) - var(--tg-content-safe-area-inset-bottom)
   );
+  /* Allow scrolling past the last talk so it isn't hidden by the fixed footer */
+  padding-bottom: calc(var(--footer-height) + var(--tg-content-safe-area-inset-bottom));
 }
 
 .talks-container {


### PR DESCRIPTION
## Summary
- ensure last talk can scroll above fixed footer by adding bottom padding

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dd243fa508328859ee1f8f0e88ad0