### PR TITLE
Fix speaker field not populated when editing talks

### DIFF
--- a/frontend/components/forms.js
+++ b/frontend/components/forms.js
@@ -100,10 +100,9 @@ export function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
 
   useEffect(() => {
     if (!speakerRef.current) return;
-    (initial.speakerIds || []).forEach(id => {
-      const opt = speakerRef.current?.querySelector(`option[value="${id}"]`);
-      if (opt) opt.selected = true;
-    });
+    // Recreate the Choices instance every time we edit a talk or the speaker
+    // list changes so that previously selected speakers are shown when
+    // editing.
     choicesRef.current = new Choices(speakerRef.current, {
       removeItemButton: true,
       searchEnabled: true,
@@ -111,8 +110,11 @@ export function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
       itemSelectText: '',
       shouldSort: false,
     });
+    const ids = initial.speakerIds || [];
+    ids.forEach(id => choicesRef.current.setChoiceByValue(id));
+    setSpeakerIds(ids);
     return () => choicesRef.current?.destroy();
-  }, [speakers]);
+  }, [speakers, initial]);
 
   const handleSubmit = ev => {
     ev.preventDefault();


### PR DESCRIPTION
## Summary
- Ensure existing speakers are preselected when editing a talk by reinitializing Choices with current speaker IDs.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m py_compile app.py migrate_json_to_sqlite.py storage.py`


------
https://chatgpt.com/codex/tasks/task_e_689dd54516d88328bfacc2b7bfad1da5