### PR TITLE
Fix mobile focus for speaker selector

### DIFF
--- a/frontend/components/forms.js
+++ b/frontend/components/forms.js
@@ -117,6 +117,12 @@ export function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
       shouldSort: false,
     });
 
+    const input = choicesRef.current.input.element;
+    const container = choicesRef.current.containerOuter.element;
+    const focusInput = () => input.focus();
+    container.addEventListener('click', focusInput);
+    container.addEventListener('touchstart', focusInput);
+
     const ids = (initial.speakerIds || []).map(String);
     if (ids.length) {
       // Ensure the required speakers are selected even if the `selected`
@@ -124,8 +130,11 @@ export function TalkForm({ initial = {}, speakers, onSubmit, onCancel }) {
       choicesRef.current.setChoiceByValue(ids);
     }
     setSpeakerIds(ids);
-
-    return () => choicesRef.current?.destroy();
+    return () => {
+      container.removeEventListener('click', focusInput);
+      container.removeEventListener('touchstart', focusInput);
+      choicesRef.current?.destroy();
+    };
   }, [speakers, initial]);
 
   const handleSubmit = ev => {


### PR DESCRIPTION
## Summary
- Focus Choices input when the speaker selector container is tapped
- Clean up event listeners on unmount

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689defbc394c83288b792024183b7666