### PR TITLE
fix: unify remove button background with chip

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -123,3 +123,18 @@
   gap: 4px;
 }
 
+/* Remove background from Choices.js remove buttons to match chip color */
+.choices__item .choices__button {
+  background-color: transparent !important;
+  border: none;
+}
+
+.choices__item .choices__button::after {
+  color: #fff;
+}
+
+.choices__item .choices__button:hover,
+.choices__item .choices__button:focus {
+  background-color: transparent !important;
+}
+


### PR DESCRIPTION
## Summary
- remove Choices.js chip remove button background and border
- ensure remove button color matches chip style

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df22dc3108328ab157dda9da72ce1