### PR TITLE
Fix header layering and footer background

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -435,7 +435,7 @@ body {
   background: var(--tg-secondary-bg-color, rgba(0,0,0,0.1));
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 1000;
 }
 
 .main-header h1 {
@@ -533,7 +533,9 @@ body {
   display: flex;
   justify-content: center;
   gap: 2rem;
-  background: var(--tg-secondary-bg-color, rgba(0,0,0,0.1));
+  background-color: var(--tg-secondary-bg-color, #fff);
+  opacity: 1;
+  backdrop-filter: none;
   padding-bottom: var(--tg-content-safe-area-inset-bottom);
   height: var(--bottom-nav-height);
 }
@@ -578,7 +580,9 @@ body {
   right: 0;
   height: var(--footer-height);
   padding-bottom: var(--tg-content-safe-area-inset-bottom);
-  background: var(--tg-secondary-bg-color, rgba(0,0,0,0.1));
+  background-color: var(--tg-secondary-bg-color, #fff);
+  opacity: 1;
+  backdrop-filter: none;
   z-index: 10;
 }
 


### PR DESCRIPTION
## Summary
- ensure main header stays above page content with high z-index
- remove transparency from bottom navigation footer for solid background

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689df4f1e21c8328b79a1075c0a9b928