### PR TITLE
Remove highlight from speaker chip remove button

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -134,7 +134,9 @@
 }
 
 .choices__item .choices__button:hover,
-.choices__item .choices__button:focus {
+.choices__item .choices__button:focus,
+.choices__item .choices__button:active {
   background-color: transparent !important;
+  outline: none;
 }
 


### PR DESCRIPTION
## Summary
- prevent the Choices.js remove button in talk speaker chips from showing background highlight

## Testing
- `npm test` (fails: missing package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e00cfa974832889d38f7c5d641760