### PR TITLE
feat: fix header offset with Telegram safe area

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -11,19 +11,17 @@ const { useState, useEffect } = React;
 const sheetRoot = ReactDOM.createRoot(document.getElementById('bottom-sheet-root'));
 const tg = window.Telegram?.WebApp;
 
-function updateSafeArea() {
-  const safe = tg?.safeAreaInset;
-  const contentSafe = tg?.contentSafeAreaInset;
-  if (safe) {
-    document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
-    document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
-  }
-  if (contentSafe) {
-    document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
-    document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
-    document.documentElement.style.setProperty('--tg-content-safe-area-inset-top', `${contentSafe.top}px`);
-    document.documentElement.style.setProperty('--tg-content-safe-area-inset-bottom', `${contentSafe.bottom}px`);
-  }
+function applyContentSafeArea() {
+  const top = tg?.contentSafeAreaInset?.top ?? 0;
+  const bottom = tg?.contentSafeAreaInset?.bottom ?? 0;
+  document.documentElement.style.setProperty(
+    '--tg-content-safe-area-inset-top',
+    `${top}px`
+  );
+  document.documentElement.style.setProperty(
+    '--tg-content-safe-area-inset-bottom',
+    `${bottom}px`
+  );
 }
 
 function App() {
@@ -156,9 +154,8 @@ const tryExpand = () => {
     // Новый вариант API — web_app_setup_swipe_behavior
     tg.postEvent('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
   }
-  tg.requestSafeArea?.();
   tg.requestContentSafeArea?.();
-  updateSafeArea();
+  applyContentSafeArea();
 };
 // Инициализируем при загрузке
 if (document.readyState === 'loading') {
@@ -166,9 +163,7 @@ if (document.readyState === 'loading') {
 } else {
   tryExpand();
 }
-tg?.onEvent?.('safeAreaChanged', updateSafeArea);
-tg?.onEvent?.('safe_area_changed', updateSafeArea);
-tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
-tg?.onEvent?.('content_safe_area_changed', updateSafeArea);
+tg?.onEvent?.('contentSafeAreaChanged', applyContentSafeArea);
+tg?.onEvent?.('content_safe_area_changed', applyContentSafeArea);
 
 ReactDOM.createRoot(document.getElementById('root')).render(e(App));

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -5,7 +5,16 @@
   --content-safe-area-bottom: 0px;
   --tg-content-safe-area-inset-top: 0px;
   --tg-content-safe-area-inset-bottom: 0px;
-  --header-height: 64px;
+  /* height of Telegram overlay buttons (capsule) */
+  --tg-overlay-buttons-height: 44px;
+  /* extra spacing below overlay buttons */
+  --header-extra-gap: 8px;
+  /* total top offset for the header */
+  --header-top-offset: calc(
+    var(--tg-content-safe-area-inset-top) +
+    var(--tg-overlay-buttons-height) +
+    var(--header-extra-gap)
+  );
   --footer-height: var(--bottom-nav-height);
   /* Lift speaker images higher on the screen */
   --speaker-top: 20px;
@@ -94,18 +103,13 @@ html.admin-page {
 
 .talks-page {
   height: 100%;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
 }
 
 .talks-scroll {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
-  height: calc(
-    100% - var(--header-height) - var(--footer-height) - var(--tg-content-safe-area-inset-top) - var(--tg-content-safe-area-inset-bottom)
-  );
-  /* Allow scrolling past the last talk so it isn't hidden by the fixed footer */
-  padding-bottom: calc(var(--footer-height) + var(--tg-content-safe-area-inset-bottom));
 }
 
 .talks-container {
@@ -431,11 +435,11 @@ body {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: calc(var(--tg-content-safe-area-inset-top) + 16px) 16px 8px;
-  background: var(--tg-secondary-bg-color, rgba(0,0,0,0.1));
+  padding: var(--header-top-offset) 16px 8px;
+  background: #fff;
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 1000;
 }
 
 .main-header h1 {
@@ -574,16 +578,11 @@ body {
 }
 
 .talks-page footer {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
   height: var(--footer-height);
   padding-bottom: var(--tg-content-safe-area-inset-bottom);
   background-color: var(--tg-secondary-bg-color, #fff);
   opacity: 1;
   backdrop-filter: none;
-  z-index: 10;
 }
 
 .talks-page footer .bottom-nav {


### PR DESCRIPTION
## Summary
- ensure header sits below Telegram overlay buttons using dynamic top offset
- only talks list scrolls; header and footer remain visible
- set content safe area from Telegram WebApp API

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e079d300c8328a7b4bfc058353181