### PR TITLE
feat: implement unified header with safe-area handling

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -1,35 +1,12 @@
 /* Styles specific to the admin interface */
 
 .admin-page {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
   background: #f5f5f5;
   color: #000;
-  /* Scrolling handled by .admin-content */
-  overflow-y: hidden;
-  overscroll-behavior-y: contain;
-  -webkit-overflow-scrolling: touch;
-}
-
-.admin-page header {
-  background: #03a9f4;
-  color: #fff;
-  padding: 16px;
-  text-align: center;
-  position: sticky;
-  top: 0;
-  z-index: 5;
 }
 
 .admin-content {
-  flex: 1;
   padding: 10px;
-  overflow-y: auto;
-  /* allow slight pull-down to avoid Telegram browser minimization */
-  height: calc(100vh - var(--bottom-nav-height));
-  overscroll-behavior-y: contain;
-  -webkit-overflow-scrolling: touch;
   /* account for safe areas and fixed bottom navigation */
   padding-bottom: calc(var(--bottom-nav-height) + var(--safe-area-bottom));
 }
@@ -45,21 +22,6 @@
 .admin-list {
   display: flex;
   flex-direction: column;
-}
-
-/* Add spacing after the "Add" buttons */
-.admin-list > button {
-  margin-bottom: 10px;
-}
-
-.admin-tabs {
-  display: flex;
-  gap: 10px;
-  margin-bottom: 20px;
-}
-
-.admin-tabs button {
-  flex: 1;
 }
 
 .admin-list-item {

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -5,19 +5,31 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Admin</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="styles/header.css" />
   <link rel="stylesheet" href="admin.css" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <!-- Telegram WebApp JS -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <script src="safe-area.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
 </head>
 <body class="admin-page page">
-  <header>
-    <h1>Панель администратора</h1>
+  <header class="app-header app-header--hero">
+    <div class="app-header__spacer" aria-hidden="true"></div>
+    <div class="app-header__bar">
+      <h1 class="app-header__title">Панель администратора</h1>
+    </div>
+    <div class="app-header__subbar app-header__subbar--tabs">
+      <button class="tab is-active" id="tab-speakers">Спикеры</button>
+      <button class="tab" id="tab-talks">Выступления</button>
+      <button class="cta" id="add-speaker">Добавить спикера</button>
+    </div>
   </header>
-  <main id="admin-root" class="admin-content"></main>
+  <main class="page__scroll">
+    <div id="admin-root" class="admin-content"></div>
+  </main>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
     <a href="/stats" id="stats-link" title="Статистика">📊</a>
@@ -38,7 +50,7 @@
       if (cfg.mode !== 'debug' && !isAdmin) {
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
-        document.querySelector('main.admin-content').innerHTML = 'Доступ запрещён';
+        document.getElementById('admin-root').innerHTML = 'Доступ запрещён';
         return;
       }
       function updateSafeArea() {

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -19,6 +19,48 @@ function AdminApp() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    const btnSpeakers = document.getElementById('tab-speakers');
+    const btnTalks = document.getElementById('tab-talks');
+
+    const handleSpeakers = () => {
+      setEditingSpeaker(null);
+      setEditingTalk(null);
+      setTab('speakers');
+    };
+    const handleTalks = () => {
+      setEditingSpeaker(null);
+      setEditingTalk(null);
+      setTab('talks');
+    };
+
+    btnSpeakers?.addEventListener('click', handleSpeakers);
+    btnTalks?.addEventListener('click', handleTalks);
+
+    return () => {
+      btnSpeakers?.removeEventListener('click', handleSpeakers);
+      btnTalks?.removeEventListener('click', handleTalks);
+    };
+  }, []);
+
+  useEffect(() => {
+    const btnSpeakers = document.getElementById('tab-speakers');
+    const btnTalks = document.getElementById('tab-talks');
+    const addBtn = document.getElementById('add-speaker');
+    if (!btnSpeakers || !btnTalks || !addBtn) return;
+    if (tab === 'speakers') {
+      btnSpeakers.classList.add('is-active');
+      btnTalks.classList.remove('is-active');
+      addBtn.textContent = 'Добавить спикера';
+      addBtn.onclick = () => setEditingSpeaker({});
+    } else {
+      btnTalks.classList.add('is-active');
+      btnSpeakers.classList.remove('is-active');
+      addBtn.textContent = 'Добавить выступление';
+      addBtn.onclick = () => setEditingTalk({});
+    }
+  }, [tab]);
+
+  useEffect(() => {
     const load = async () => {
         const tg = window.Telegram?.WebApp;
         tg?.ready();
@@ -119,7 +161,6 @@ function AdminApp() {
   const speakerSection = editingSpeaker ?
     e(SpeakerForm, { initial: editingSpeaker, onSubmit: saveSpeaker, onCancel: () => setEditingSpeaker(null) }) :
     e('div', { className: 'admin-list' },
-      e('button', { onClick: () => setEditingSpeaker({}) }, 'Добавить спикера'),
       speakers.map(s => e('div', { key: s.id, className: 'admin-list-item' },
         e('span', { className: 'admin-item-name' }, s.name),
         e('div', { className: 'admin-actions' },
@@ -140,7 +181,6 @@ function AdminApp() {
   const talkSection = editingTalk ?
     e(TalkForm, { initial: editingTalk, speakers, onSubmit: saveTalk, onCancel: () => setEditingTalk(null) }) :
     e('div', { className: 'admin-list' },
-      e('button', { onClick: () => setEditingTalk({}) }, 'Добавить выступление'),
       talks.map(t => {
         const names = speakers.filter(s => (t.speakerIds || []).includes(s.id)).map(s => s.name).join(', ');
         return e('div', { key: t.id, className: 'admin-list-item' },
@@ -163,20 +203,6 @@ function AdminApp() {
 
   return e('div', null,
     error && e('div', { className: 'error' }, error),
-    e('div', { className: 'admin-tabs' },
-      e('button', {
-        onClick: () => {
-          setEditingSpeaker(null);
-          setTab('speakers');
-        }
-      }, 'Спикеры'),
-      e('button', {
-        onClick: () => {
-          setEditingTalk(null);
-          setTab('talks');
-        }
-      }, 'Выступления')
-    ),
     tab === 'speakers' ? speakerSection : talkSection
   );
 }

--- a/frontend/safe-area.js
+++ b/frontend/safe-area.js
@@ -1,0 +1,13 @@
+(() => {
+  const tg = window.Telegram?.WebApp;
+
+  function applySafeTop() {
+    const top = tg?.contentSafeAreaInset?.top ?? 0;
+    document.documentElement.style.setProperty('--safe-top', `${top}px`);
+  }
+
+  tg?.onEvent?.('content_safe_area_changed', applySafeTop);
+  tg?.requestContentSafeArea?.();
+  applySafeTop();
+})();
+

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -5,22 +5,32 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Statistics</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="styles/header.css" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <script src="safe-area.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="stats-page page">
-  <div class="stats-wrapper">
-    <div class="chart-block">
-      <h3 class="chart-title">Доклады по направлениям</h3>
-      <canvas id="talks-chart"></canvas>
+  <header class="app-header app-header--plain">
+    <div class="app-header__spacer" aria-hidden="true"></div>
+    <div class="app-header__bar">
+      <h1 class="app-header__title">Статистика</h1>
     </div>
-    <div class="chart-block">
-      <h3 class="chart-title">Активные спикеры</h3>
-      <canvas id="speakers-chart"></canvas>
+  </header>
+  <main class="page__scroll">
+    <div class="stats-wrapper">
+      <div class="chart-block">
+        <h3 class="chart-title">Доклады по направлениям</h3>
+        <canvas id="talks-chart"></canvas>
+      </div>
+      <div class="chart-block">
+        <h3 class="chart-title">Активные спикеры</h3>
+        <canvas id="speakers-chart"></canvas>
+      </div>
     </div>
-  </div>
+  </main>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
     <a href="/stats" id="stats-link" class="active" title="Статистика">📊</a>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -73,12 +73,6 @@ html.admin-page {
 .stats-page {
   background: #f5f5f5;
   color: #000;
-  height: 100%;
-  /* allow slight pull-down to avoid Telegram browser minimization */
-  min-height: calc(100% + 20px);
-  overflow-y: auto;
-  overscroll-behavior-y: contain;
-  -webkit-overflow-scrolling: touch;
 }
 
 #profile-root {

--- a/frontend/styles/header.css
+++ b/frontend/styles/header.css
@@ -1,0 +1,134 @@
+:root {
+  /* Будут выставляться из JS */
+  --safe-top: 0px;                 /* tg.contentSafeAreaInset.top */
+  --overlay-h: 44px;               /* капсулы Telegram */
+  --header-gap: 8px;               /* воздух */
+  --header-top-offset: calc(var(--safe-top) + var(--overlay-h) + var(--header-gap));
+
+  --header-bg: #fff;
+  --header-fg: #111;
+  --shadow-sm: 0 2px 12px rgba(0,0,0,.06);
+  --shadow-md: 0 6px 24px rgba(0,0,0,.12);
+
+  --title-lg: 28px;
+  --title-md: 22px;
+  --title-w-b: 800;
+  --title-w-sb: 700;
+
+  --hero-bg: #0ecbff;              /* фирменный голубой */
+  --hero-fg: #fff;
+  --tab-bg: #eaf9ff;
+  --tab-active-bg: #9be8ff;
+  --cta-bg: #12e7ff;
+}
+
+/* Базовая шапка */
+.app-header {
+  position: sticky;         /* можно fixed, если нужно */
+  top: 0;
+  z-index: 1000;
+  background: var(--header-bg);
+  color: var(--header-fg);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Spacer уводит шапку из-под Close/стрелки */
+.app-header__spacer { height: var(--header-top-offset); }
+
+/* Основная строка */
+.app-header__bar {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+}
+
+.app-header__title {
+  margin: 0;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+}
+
+/* Варианты */
+.app-header--plain .app-header__title {
+  font-size: var(--title-md);
+  font-weight: var(--title-w-sb);
+}
+
+.app-header--hero {
+  background: var(--hero-bg);
+  color: var(--hero-fg);
+  box-shadow: var(--shadow-md);
+}
+
+.app-header--hero .app-header__bar {
+  padding-top: 16px;
+  padding-bottom: 16px;
+}
+
+.app-header--hero .app-header__title {
+  font-size: var(--title-lg);
+  font-weight: var(--title-w-b);
+}
+
+/* Подбар (табы/кнопки) */
+.app-header__subbar {
+  padding: 10px 16px 14px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+/* Табы и кнопки */
+.app-header__subbar .tab {
+  border: 0;
+  padding: 10px 16px;
+  border-radius: 14px;
+  background: var(--tab-bg);
+  color: #063a47;
+  font-weight: 600;
+}
+
+.app-header__subbar .tab.is-active {
+  background: var(--tab-active-bg);
+}
+
+.app-header__subbar .cta {
+  margin-left: auto;
+  border: 0;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: var(--cta-bg);
+  color: #063a47;
+  font-weight: 700;
+  box-shadow: 0 6px 20px rgba(18, 231, 255, 0.35);
+}
+
+/* Страница: фиксируем футер, скролл только у контента */
+html, body { height: 100%; }
+body { overflow: hidden; }
+.page {
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr auto;  /* header | content | footer */
+}
+.page__scroll {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  background: #f7f7f7;
+}
+.app-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 1000;
+  background: #fff;              /* непрозрачный */
+  box-shadow: 0 -2px 12px rgba(0,0,0,.06);
+}
+
+/* Мелкие адаптивные правки */
+@media (max-width: 360px) {
+  .app-header--hero .app-header__title { font-size: 24px; }
+}
+


### PR DESCRIPTION
## Summary
- add reusable header component with safe-area support
- apply new header to admin and stats pages
- move admin tabs and add button into header with dynamic JS handlers

## Testing
- `node --check frontend/admin.js && echo "admin.js ok"`
- `node --check frontend/safe-area.js && echo "safe-area.js ok"`
- `python -m py_compile $(git ls-files "*.py") && echo "python ok"`


------
https://chatgpt.com/codex/tasks/task_e_689e64e71c588328b37ddf19c3c97c51