### PR TITLE
feat: remove time from talk card date display

### DIFF
--- a/frontend/components/TalkCard.js
+++ b/frontend/components/TalkCard.js
@@ -7,9 +7,7 @@ const formatDate = d => {
   const dd = String(date.getDate()).padStart(2, '0');
   const mm = String(date.getMonth() + 1).padStart(2, '0');
   const yyyy = date.getFullYear();
-  const hh = String(date.getHours()).padStart(2, '0');
-  const mi = String(date.getMinutes()).padStart(2, '0');
-  return `${dd}.${mm}.${yyyy} ${hh}:${mi}`;
+  return `${dd}.${mm}.${yyyy}`;
 };
 
 export function TalkCard({ talk, speakers = [], onSelect }) {


### PR DESCRIPTION
## Summary
- simplify TalkCard date formatting to show only day, month and year

## Testing
- `python -m pytest`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f0aef6e58832882848c8aa9c20fef