### PR TITLE
Handle missing Telegram WebApp in tryExpand

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -40,7 +40,8 @@
         }
       }
       const tryExpand = () => {
-        tg.ready();
+        if (!tg) return;
+        tg.ready?.();
         tg.expand?.();
         tg.requestFullscreen?.();
         tg.disableVerticalSwipes?.();


### PR DESCRIPTION
## Summary
- guard tg access in index.html's tryExpand to allow running without Telegram
- use optional calls to request WebApp APIs safely

## Testing
- `python -m py_compile app.py migrate_json_to_sqlite.py storage.py`


------
https://chatgpt.com/codex/tasks/task_e_689f129ec43c8328b7d75af99c892e88