### PR TITLE
Fix header offset to remove extra top space

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -5,16 +5,8 @@
   --content-safe-area-bottom: 0px;
   --tg-content-safe-area-inset-top: 0px;
   --tg-content-safe-area-inset-bottom: 0px;
-  /* height of Telegram overlay buttons (capsule) */
-  --tg-overlay-buttons-height: 44px;
-  /* extra spacing below overlay buttons */
-  --header-extra-gap: 8px;
-  /* total top offset for the header */
-  --header-top-offset: calc(
-    var(--tg-content-safe-area-inset-top) +
-    var(--tg-overlay-buttons-height) +
-    var(--header-extra-gap)
-  );
+  /* total top offset for the header (overlay buttons already included) */
+  --header-top-offset: var(--tg-content-safe-area-inset-top);
   --footer-height: var(--bottom-nav-height);
   /* Lift speaker images higher on the screen */
   --speaker-top: 20px;

--- a/frontend/styles/header.css
+++ b/frontend/styles/header.css
@@ -1,9 +1,9 @@
 :root {
   /* Будут выставляться из JS */
   --safe-top: 0px;                 /* tg.contentSafeAreaInset.top */
-  --overlay-h: 44px;               /* капсулы Telegram */
-  --header-gap: 8px;               /* воздух */
-  --header-top-offset: calc(var(--safe-top) + var(--overlay-h) + var(--header-gap));
+  /* Telegram now includes overlay buttons in content safe area,
+     so use the value directly without extra offsets */
+  --header-top-offset: var(--safe-top);
 
   --header-bg: #fff;
   --header-fg: #111;


### PR DESCRIPTION
## Summary
- rely solely on Telegram's safe area value for header positioning
- eliminate outdated overlay and gap offsets

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689f23e2770083288340b41d1a24daeb