### PR TITLE
refactor: adopt app-header layout

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,7 +1,7 @@
 import { TalkCard } from './components/TalkCard.js';
 import { FilterPanel } from './components/FilterPanel.js';
 import { NavigationBar } from './components/NavigationBar.js';
-import { Header } from './components/Header.js';
+import { Header } from './components/Header.js'; // app-header layout
 import { useTalkData } from './hooks/useTalkData.js';
 
 const e = React.createElement;

--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -3,16 +3,21 @@ const e = React.createElement;
 export function Header({ onToggleFilters, filtersOpen }) {
   return e(
     'header',
-    { className: 'main-header' },
-    e('h1', null, 'Доклады'),
+    { className: 'app-header app-header--plain' },
+    e('div', { className: 'app-header__spacer', 'aria-hidden': 'true' }),
     e(
-      'button',
-      {
-        onClick: onToggleFilters,
-        'aria-pressed': filtersOpen,
-        'aria-label': 'Показать фильтры',
-      },
-      'Фильтры'
+      'div',
+      { className: 'app-header__bar' },
+      e('h1', { className: 'app-header__title' }, 'Доклады'),
+      e(
+        'button',
+        {
+          onClick: onToggleFilters,
+          'aria-pressed': filtersOpen,
+          'aria-label': 'Показать фильтры',
+        },
+        'Фильтры'
+      )
     )
   );
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Speakers Platform</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="styles/header.css" />
   <!-- React and dependencies from CDN -->
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
@@ -14,6 +15,7 @@
 <body class="page talks-body">
   <div id="root"></div>
   <script src="/config.js"></script>
+  <script src="safe-area.js"></script>
   <script>
     (function() {
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -417,22 +417,6 @@ body {
   color: var(--tg-text-color, #000000);
 }
 
-.main-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: var(--header-top-offset) 16px 8px;
-  background: #fff;
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-}
-
-.main-header h1 {
-  margin: 0;
-  font-size: 1.2rem;
-}
-
 
 .filter-panel {
   background: var(--tg-secondary-bg-color, #fff);


### PR DESCRIPTION
## Summary
- replace legacy main header markup with `app-header` structure
- load `styles/header.css` and `safe-area.js`
- drop obsolete `.main-header` rules

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f2f90f20c83289cda79a3c870dc27