### PR TITLE
Centralize safe area handling in frontend

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -52,30 +52,13 @@
         document.getElementById('admin-root').innerHTML = 'Доступ запрещён';
         return;
       }
-      function updateSafeArea() {
-        const safe = tg?.safeAreaInset;
-        const contentSafe = tg?.contentSafeAreaInset;
-        if (safe) {
-          document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
-          document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
-        }
-        if (contentSafe) {
-          document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
-          document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
-        }
-      }
       const tryExpand = () => {
           tg.ready();
           tg.expand?.();
           tg.requestFullscreen?.();
           tg.disableVerticalSwipes?.();
           tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
-          tg.requestSafeArea?.();
-          tg.requestContentSafeArea?.();
-          updateSafeArea();
       };
-      tg?.onEvent?.('safeAreaChanged', updateSafeArea);
-      tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);
       } else {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,20 +27,6 @@
       }
       const isAdmin = user && cfg.admins.includes(user.username);
       window.__IS_ADMIN__ = cfg.mode === 'debug' || isAdmin;
-      function updateSafeArea() {
-        const safe = tg?.safeAreaInset;
-        const contentSafe = tg?.contentSafeAreaInset;
-        if (safe) {
-          document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
-          document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
-        }
-        if (contentSafe) {
-          document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
-          document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
-          document.documentElement.style.setProperty('--tg-content-safe-area-inset-top', `${contentSafe.top}px`);
-          document.documentElement.style.setProperty('--tg-content-safe-area-inset-bottom', `${contentSafe.bottom}px`);
-        }
-      }
       const tryExpand = () => {
         if (!tg) return;
         tg.ready?.();
@@ -48,14 +34,7 @@
         tg.requestFullscreen?.();
         tg.disableVerticalSwipes?.();
         tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
-        tg.requestSafeArea?.();
-        tg.requestContentSafeArea?.();
-        updateSafeArea();
       };
-      tg?.onEvent?.('safeAreaChanged', updateSafeArea);
-      tg?.onEvent?.('safe_area_changed', updateSafeArea);
-      tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
-      tg?.onEvent?.('content_safe_area_changed', updateSafeArea);
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);
       } else {

--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -18,6 +18,7 @@
     <a href="/profile" class="active" title="Личный кабинет">👤</a>
   </nav>
   <script src="/config.js"></script>
+  <script src="safe-area.js"></script>
   <script>
     (function() {
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };
@@ -32,30 +33,13 @@
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }
-      function updateSafeArea() {
-        const safe = tg?.safeAreaInset;
-        const contentSafe = tg?.contentSafeAreaInset;
-        if (safe) {
-          document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
-          document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
-        }
-        if (contentSafe) {
-          document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
-          document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
-        }
-      }
       const tryExpand = () => {
           tg.ready();
           tg.expand?.();
           tg.requestFullscreen?.();
           tg.disableVerticalSwipes?.();
           tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
-          tg.requestSafeArea?.();
-          tg.requestContentSafeArea?.();
-          updateSafeArea();
       };
-      tg?.onEvent?.('safeAreaChanged', updateSafeArea);
-      tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);
       } else {

--- a/frontend/safe-area.js
+++ b/frontend/safe-area.js
@@ -1,13 +1,48 @@
 (() => {
   const tg = window.Telegram?.WebApp;
 
-  function applySafeTop() {
-    const top = tg?.contentSafeAreaInset?.top ?? 0;
-    document.documentElement.style.setProperty('--safe-top', `${top}px`);
+  function applySafeArea() {
+    const safe = tg?.safeAreaInset || {};
+    const contentSafe = tg?.contentSafeAreaInset || {};
+    const top = contentSafe.top ?? safe.top ?? 0;
+    const bottom = contentSafe.bottom ?? safe.bottom ?? 0;
+
+    document.documentElement.style.setProperty(
+      '--tg-content-safe-area-inset-top',
+      `${top}px`
+    );
+    document.documentElement.style.setProperty(
+      '--tg-content-safe-area-inset-bottom',
+      `${bottom}px`
+    );
+    document.documentElement.style.setProperty(
+      '--content-safe-area-top',
+      `${contentSafe.top ?? 0}px`
+    );
+    document.documentElement.style.setProperty(
+      '--content-safe-area-bottom',
+      `${contentSafe.bottom ?? 0}px`
+    );
+    document.documentElement.style.setProperty(
+      '--safe-area-top',
+      `${safe.top ?? top}px`
+    );
+    document.documentElement.style.setProperty(
+      '--safe-area-bottom',
+      `${safe.bottom ?? bottom}px`
+    );
+    document.documentElement.style.setProperty(
+      '--safe-top',
+      `${top}px`
+    );
   }
 
-  tg?.onEvent?.('content_safe_area_changed', applySafeTop);
-  tg?.requestContentSafeArea?.();
-  applySafeTop();
-})();
+  tg?.onEvent?.('safeAreaChanged', applySafeArea);
+  tg?.onEvent?.('safe_area_changed', applySafeArea);
+  tg?.onEvent?.('contentSafeAreaChanged', applySafeArea);
+  tg?.onEvent?.('content_safe_area_changed', applySafeArea);
 
+  tg?.requestSafeArea?.();
+  tg?.requestContentSafeArea?.();
+  applySafeArea();
+})();

--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -52,30 +52,13 @@
         document.getElementById('admin-link')?.remove();
         document.getElementById('stats-link')?.remove();
       }
-      function updateSafeArea() {
-        const safe = tg?.safeAreaInset;
-        const contentSafe = tg?.contentSafeAreaInset;
-        if (safe) {
-          document.documentElement.style.setProperty('--safe-area-top', `${safe.top}px`);
-          document.documentElement.style.setProperty('--safe-area-bottom', `${safe.bottom}px`);
-        }
-        if (contentSafe) {
-          document.documentElement.style.setProperty('--content-safe-area-top', `${contentSafe.top}px`);
-          document.documentElement.style.setProperty('--content-safe-area-bottom', `${contentSafe.bottom}px`);
-        }
-      }
       const tryExpand = () => {
           tg.ready();
           tg.expand?.();
           tg.requestFullscreen?.();
           tg.disableVerticalSwipes?.();
           tg.postEvent?.('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
-          tg.requestSafeArea?.();
-          tg.requestContentSafeArea?.();
-          updateSafeArea();
       };
-      tg?.onEvent?.('safeAreaChanged', updateSafeArea);
-      tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
       if (document.readyState === 'loading') {
         window.addEventListener('DOMContentLoaded', tryExpand);
       } else {

--- a/frontend/styles/header.css
+++ b/frontend/styles/header.css
@@ -1,9 +1,9 @@
 :root {
   /* Будут выставляться из JS */
-  --safe-top: 0px;                 /* tg.contentSafeAreaInset.top */
+  --tg-content-safe-area-inset-top: 0px; /* tg.contentSafeAreaInset.top */
   /* Telegram now includes overlay buttons in content safe area,
      so use the value directly without extra offsets */
-  --header-top-offset: var(--safe-top);
+  --header-top-offset: var(--tg-content-safe-area-inset-top);
 
   --header-bg: #fff;
   --header-fg: #111;
@@ -131,4 +131,3 @@ body { overflow: hidden; }
 @media (max-width: 360px) {
   .app-header--hero .app-header__title { font-size: 24px; }
 }
-


### PR DESCRIPTION
## Summary
- handle Telegram safe area insets in a single `safe-area.js`
- remove duplicate safe area logic from individual pages
- use content safe area inset to offset header

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f33ad9a04832886c8dd2032077d5e