### PR TITLE
Add header to profile page

### DIFF
--- a/frontend/profile.html
+++ b/frontend/profile.html
@@ -5,12 +5,20 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Profile</title>
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="styles/header.css" />
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <script src="safe-area.js"></script>
 </head>
 <body class="page">
-  <div id="profile-root"></div>
+  <header class="app-header app-header--plain">
+    <div class="app-header__spacer" aria-hidden="true"></div>
+    <div class="app-header__bar"></div>
+  </header>
+  <main class="page__scroll">
+    <div id="profile-root"></div>
+  </main>
   <nav class="bottom-nav">
     <a href="/" title="Выступления">🎤</a>
     <a href="/stats" id="stats-link" title="Статистика">📊</a>
@@ -18,7 +26,6 @@
     <a href="/profile" class="active" title="Личный кабинет">👤</a>
   </nav>
   <script src="/config.js"></script>
-  <script src="safe-area.js"></script>
   <script>
     (function() {
       const cfg = window.APP_CONFIG || { mode: 'prod', admins: [] };

--- a/frontend/profile.js
+++ b/frontend/profile.js
@@ -29,6 +29,13 @@ function ProfileApp() {
     updateSafeArea();
     tg?.onEvent?.('safeAreaChanged', updateSafeArea);
     tg?.onEvent?.('contentSafeAreaChanged', updateSafeArea);
+    const bar = document.querySelector('.app-header__bar');
+    if (bar) {
+      const title = document.createElement('h1');
+      title.className = 'app-header__title';
+      title.textContent = 'Личный кабинет';
+      bar.appendChild(title);
+    }
   }, []);
 
   if (!user) {
@@ -36,7 +43,6 @@ function ProfileApp() {
   }
 
   return e('div', null,
-    e('h2', null, 'Личный кабинет'),
     e('div', null, `Имя: ${user.first_name} ${user.last_name || ''}`),
     e('div', null, `Username: @${user.username || ''}`)
   );


### PR DESCRIPTION
## Summary
- add shared header styles and safe-area script to profile page
- render "Личный кабинет" header before profile content

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f37bb80a0832883f4188f24fed29a