### PR TITLE
Fix header safe-area offsets and remove redundant padding

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -9,19 +9,6 @@ const { useState, useEffect } = React;
 
 const tg = window.Telegram?.WebApp;
 
-function applyContentSafeArea() {
-  const top = tg?.contentSafeAreaInset?.top ?? 0;
-  const bottom = tg?.contentSafeAreaInset?.bottom ?? 0;
-  document.documentElement.style.setProperty(
-    '--tg-content-safe-area-inset-top',
-    `${top}px`
-  );
-  document.documentElement.style.setProperty(
-    '--tg-content-safe-area-inset-bottom',
-    `${bottom}px`
-  );
-}
-
 function App() {
   const [filters, setFilters] = useState({
     direction: 'all',
@@ -155,8 +142,6 @@ const tryExpand = () => {
     // Новый вариант API — web_app_setup_swipe_behavior
     tg.postEvent('web_app_setup_swipe_behavior', JSON.stringify({ allow_vertical_swipe: false }));
   }
-  tg.requestContentSafeArea?.();
-  applyContentSafeArea();
 };
 // Инициализируем при загрузке
 if (document.readyState === 'loading') {
@@ -164,7 +149,5 @@ if (document.readyState === 'loading') {
 } else {
   tryExpand();
 }
-tg?.onEvent?.('contentSafeAreaChanged', applyContentSafeArea);
-tg?.onEvent?.('content_safe_area_changed', applyContentSafeArea);
 
 ReactDOM.createRoot(document.getElementById('root')).render(e(App));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,7 @@
   <!-- Telegram WebApp JS to access Telegram features -->
   <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
-<body class="page talks-body">
+<body class="page talks-body" style="--header-extra-top: 8px;">
   <div id="root"></div>
   <script src="/config.js"></script>
   <script src="safe-area.js"></script>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -35,7 +35,6 @@ html, body {
 
 /* Provide default safe area offsets for page containers */
 .page {
-  padding-top: calc(var(--tg-content-safe-area-inset-top) + 12px);
   padding-bottom: var(--tg-content-safe-area-inset-bottom);
 }
 

--- a/frontend/styles/header.css
+++ b/frontend/styles/header.css
@@ -2,8 +2,11 @@
   /* Будут выставляться из JS */
   --tg-content-safe-area-inset-top: 0px; /* tg.contentSafeAreaInset.top */
   /* Telegram now includes overlay buttons in content safe area,
-     so use the value directly without extra offsets */
-  --header-top-offset: var(--tg-content-safe-area-inset-top);
+     so use the value directly plus optional extra padding */
+  --header-extra-top: 0px;
+  --header-top-offset: calc(
+    var(--tg-content-safe-area-inset-top) + var(--header-extra-top)
+  );
 
   --header-bg: #fff;
   --header-fg: #111;


### PR DESCRIPTION
## Summary
- add optional extra top padding to app header and use it on talks page
- remove unnecessary top padding on non-talk pages and centralize safe-area handling

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'py_compile success'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f3f50382483288603ccb1f3820311