### PR TITLE
feat: enhance speaker tag selection

### DIFF
--- a/frontend/tags.js
+++ b/frontend/tags.js
@@ -1,2 +1,2 @@
-export const TAGS = ['frontend','backend','QA','mobile','product','data','manager'];
+export const TAGS = ['frontend','backend','QA','mobile','product','data','manager','AI','embedded'];
 


### PR DESCRIPTION
## Summary
- replace speaker tag checkboxes with searchable multiselect like talk speaker field
- add AI and embedded tag options

## Testing
- `node --check frontend/components/forms.js`
- `node --check frontend/tags.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689f4242d69883288f3173272360c720