### PR TITLE
Adjust header for Telegram safe area

### DIFF
--- a/frontend/styles/header.css
+++ b/frontend/styles/header.css
@@ -33,10 +33,11 @@
   background: var(--header-bg);
   color: var(--header-fg);
   box-shadow: var(--shadow-sm);
+  padding-top: var(--header-top-offset);
 }
 
-/* Spacer уводит шапку из-под Close/стрелки */
-.app-header__spacer { height: var(--header-top-offset); }
+/* Spacer больше не нужен, но оставлен для совместимости */
+.app-header__spacer { height: 0; }
 
 /* Основная строка */
 .app-header__bar {


### PR DESCRIPTION
## Summary
- add dynamic top padding to header using Telegram safe area
- keep legacy spacer but disable its height

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f49ad9b7c83288bb9b8ec19161983