### PR TITLE
Use unified tag list for speakers and talks

### DIFF
--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -1,4 +1,3 @@
-import { DIRECTIONS } from './directions.js';
 import { SpeakerForm, TalkForm } from './components/forms.js';
 
 const e = React.createElement;

--- a/frontend/components/FilterPanel.js
+++ b/frontend/components/FilterPanel.js
@@ -1,4 +1,4 @@
-import { DIRECTIONS } from '../directions.js';
+import { TAGS as DIRECTIONS } from '../tags.js';
 const e = React.createElement;
 
 export function FilterPanel({ filters, onChange, visible }) {

--- a/frontend/components/forms.js
+++ b/frontend/components/forms.js
@@ -1,5 +1,5 @@
-import { DIRECTIONS } from '../directions.js';
 import { TAGS } from '../tags.js';
+const DIRECTIONS = TAGS;
 const e = React.createElement;
 const { useState, useEffect } = React;
 

--- a/frontend/directions.js
+++ b/frontend/directions.js
@@ -1,1 +1,0 @@
-export const DIRECTIONS = ['frontend','backend','QA','mobile','product','data','manager'];

--- a/frontend/stats.js
+++ b/frontend/stats.js
@@ -1,4 +1,4 @@
-import { DIRECTIONS } from './directions.js';
+import { TAGS as DIRECTIONS } from './tags.js';
 import { ACCENTS } from './constants.js';
 
 async function loadData() {


### PR DESCRIPTION
## Summary
- Remove dedicated directions dictionary and reuse speaker tags for talk directions
- Update forms, filter panel, and stats to source directions from tag list
- Clean up unused directions import in admin interface

## Testing
- `node --check frontend/stats.js`
- `node --check frontend/components/forms.js`
- `node --check frontend/components/FilterPanel.js`
- `node --check frontend/admin.js`
- `python -m py_compile app.py storage.py migrate_json_to_sqlite.py`


------
https://chatgpt.com/codex/tasks/task_e_689f618471388328b19145843d351b2f