### PR TITLE
Reduce app header top padding by 60px

### DIFF
--- a/frontend/styles/header.css
+++ b/frontend/styles/header.css
@@ -33,7 +33,7 @@
   background: var(--header-bg);
   color: var(--header-fg);
   box-shadow: var(--shadow-sm);
-  padding-top: calc(var(--header-top-offset) + 150px);
+  padding-top: calc(var(--header-top-offset) + 90px);
 }
 
 /* Spacer больше не нужен, но оставлен для совместимости */


### PR DESCRIPTION
## Summary
- subtract 60px from app header's top padding for improved spacing

## Testing
- `pytest`
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f6c35cd488328b8a771295dc7606a