### PR TITLE
feat(admin): add speaker card expander

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -36,6 +36,48 @@
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
+.admin-speaker-item {
+  flex-direction: column;
+  cursor: pointer;
+}
+
+.admin-speaker-item .admin-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.admin-item-details {
+  width: 100%;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+}
+
+.admin-speaker-item.expanded .admin-item-details {
+  max-height: 500px;
+  margin-top: 8px;
+}
+
+.admin-tag {
+  background: #eee;
+  color: #000;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.collapse-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-top: 8px;
+  cursor: pointer;
+  color: #000;
+  box-shadow: none;
+}
+
 .admin-item-name {
   font-weight: 600;
   word-break: break-word;

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -14,6 +14,7 @@ function AdminApp() {
   const [talks, setTalks] = useState([]);
   const [editingSpeaker, setEditingSpeaker] = useState(null);
   const [editingTalk, setEditingTalk] = useState(null);
+  const [expandedSpeakerId, setExpandedSpeakerId] = useState(null);
   const [tab, setTab] = useState('speakers');
   const [error, setError] = useState(null);
 
@@ -119,6 +120,10 @@ function AdminApp() {
     }
   };
 
+  const toggleSpeaker = id => {
+    setExpandedSpeakerId(expandedSpeakerId === id ? null : id);
+  };
+
   const saveTalk = async data => {
     try {
       if (data.id) {
@@ -156,21 +161,43 @@ function AdminApp() {
     e(SpeakerForm, { initial: editingSpeaker, onSubmit: saveSpeaker, onCancel: () => setEditingSpeaker(null) }) :
     e('div', { className: 'admin-list' },
       e('div', { key: 'add', className: 'admin-list-item admin-add-btn', onClick: () => setEditingSpeaker({}) }, '+'),
-      speakers.map(s => e('div', { key: s.id, className: 'admin-list-item' },
-        e('span', { className: 'admin-item-name' }, s.name),
-        e('div', { className: 'admin-actions' },
-          e('button', {
-            className: 'icon-btn',
-            title: 'Редактировать',
-            onClick: () => setEditingSpeaker(s)
-          }, '✏️'),
-          e('button', {
-            className: 'icon-btn',
-            title: 'Удалить',
-            onClick: () => window.confirm('Удалить спикера?') && deleteSpeaker(s.id)
-          }, '🗑️')
-        )
-      ))
+      speakers.map(s => {
+        const expanded = expandedSpeakerId === s.id;
+        return e('div', {
+          key: s.id,
+          className: `admin-list-item admin-speaker-item${expanded ? ' expanded' : ''}`,
+          onClick: () => toggleSpeaker(s.id)
+        },
+          e('div', { className: 'admin-item-header' },
+            e('span', { className: 'admin-item-name' }, s.name),
+            e('div', {
+              className: 'admin-actions',
+              onClick: ev => ev.stopPropagation()
+            },
+              e('button', {
+                className: 'icon-btn',
+                title: 'Редактировать',
+                onClick: () => setEditingSpeaker(s)
+              }, '✏️'),
+              e('button', {
+                className: 'icon-btn',
+                title: 'Удалить',
+                onClick: () => window.confirm('Удалить спикера?') && deleteSpeaker(s.id)
+              }, '🗑️')
+            )
+          ),
+          e('div', { className: `admin-item-details${expanded ? ' expanded' : ''}` },
+            e('p', null, s.description),
+            e('div', { className: 'admin-tags' },
+              (s.tags || []).map(t => e('span', { key: t, className: 'admin-tag' }, t))
+            ),
+            e('button', {
+              className: 'collapse-btn',
+              onClick: ev => { ev.stopPropagation(); toggleSpeaker(s.id); }
+            }, 'Свернуть')
+          )
+        );
+      })
     );
 
   const talkSection = editingTalk ?


### PR DESCRIPTION
## Summary
- add speaker card expander with description and tags
- style expanded details and collapse button

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f883c1d4c8328bc8b10068a7b1389