### PR TITLE
Display speaker photos in admin list

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -48,6 +48,21 @@
   width: 100%;
 }
 
+.admin-speaker-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+}
+
+.admin-speaker-photo {
+  width: 1em;
+  height: 1em;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
 .admin-item-details {
   width: 100%;
   max-height: 0;

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -169,7 +169,10 @@ function AdminApp() {
           onClick: () => toggleSpeaker(s.id)
         },
           e('div', { className: 'admin-item-header' },
-            e('span', { className: 'admin-item-name' }, s.name),
+            e('div', { className: 'admin-speaker-info' },
+              e('img', { src: s.photoUrl || '/default_icon.svg', alt: '', className: 'admin-speaker-photo' }),
+              e('span', { className: 'admin-item-name' }, s.name)
+            ),
             e('div', {
               className: 'admin-actions',
               onClick: ev => ev.stopPropagation()


### PR DESCRIPTION
## Summary
- Show speaker's photo alongside their name on the admin speakers list
- Style speaker photo to match text height and align with speaker info

## Testing
- `node --check frontend/admin.js`
- `python -m py_compile app.py storage.py`


------
https://chatgpt.com/codex/tasks/task_e_689f8d214cbc83289dbddab39c71c2ac