### PR TITLE
feat: add speaker datalist filter to talk list

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -61,7 +61,7 @@ function App() {
     e(
       'div',
       { className: 'talks-scroll' },
-      e(FilterPanel, { filters, onChange: setFilters, visible: showFilters }),
+      e(FilterPanel, { filters, onChange: setFilters, visible: showFilters, speakers }),
       activeFilters.length > 0 &&
         e(
           'div',

--- a/frontend/components/FilterPanel.js
+++ b/frontend/components/FilterPanel.js
@@ -1,7 +1,7 @@
 import { TAGS as DIRECTIONS } from '../tags.js';
 const e = React.createElement;
 
-export function FilterPanel({ filters, onChange, visible }) {
+export function FilterPanel({ filters, onChange, visible, speakers = [] }) {
   const { direction, status, query, speaker, from, to } = filters;
   const set = (key, value) => onChange({ ...filters, [key]: value });
   const reset = () =>
@@ -22,11 +22,17 @@ export function FilterPanel({ filters, onChange, visible }) {
     }),
     e('input', {
       type: 'text',
+      list: 'speakers-list',
       placeholder: 'Спикер',
       value: speaker,
       onChange: ev => set('speaker', ev.target.value),
       'aria-label': 'Поиск по спикеру',
     }),
+    e(
+      'datalist',
+      { id: 'speakers-list' },
+      speakers.map(s => e('option', { key: s.id, value: s.name }))
+    ),
     e(
       'select',
       {


### PR DESCRIPTION
## Summary
- pass speakers list to FilterPanel and expose speaker datalist
- support speaker selection via datalist suggestions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f936ca8b4832898fb0af90408ff03