### PR TITLE
feat: debounce filter inputs

### DIFF
--- a/frontend/components/FilterPanel.js
+++ b/frontend/components/FilterPanel.js
@@ -1,9 +1,30 @@
 import { TAGS as DIRECTIONS } from '../tags.js';
+import { useDebounce } from '../hooks/useDebounce.js';
 const e = React.createElement;
+const { useState, useEffect } = React;
 
 export function FilterPanel({ filters, onChange, visible, speakers = [] }) {
   const { direction, status, query, speaker, from, to } = filters;
+
+  const [localQuery, setLocalQuery] = useState(query);
+  const [localSpeaker, setLocalSpeaker] = useState(speaker);
+
+  useEffect(() => setLocalQuery(query), [query]);
+  useEffect(() => setLocalSpeaker(speaker), [speaker]);
+
+  const debouncedQuery = useDebounce(localQuery, 300);
+  const debouncedSpeaker = useDebounce(localSpeaker, 300);
+
   const set = (key, value) => onChange({ ...filters, [key]: value });
+
+  useEffect(() => {
+    if (debouncedQuery !== query) set('query', debouncedQuery);
+  }, [debouncedQuery, query]);
+
+  useEffect(() => {
+    if (debouncedSpeaker !== speaker) set('speaker', debouncedSpeaker);
+  }, [debouncedSpeaker, speaker]);
+
   const reset = () =>
     onChange({ direction: 'all', status: 'all', query: '', speaker: '', from: '', to: '' });
 
@@ -16,16 +37,16 @@ export function FilterPanel({ filters, onChange, visible, speakers = [] }) {
     e('input', {
       type: 'text',
       placeholder: 'Название доклада',
-      value: query,
-      onChange: ev => set('query', ev.target.value),
+      value: localQuery,
+      onChange: ev => setLocalQuery(ev.target.value),
       'aria-label': 'Поиск по названию',
     }),
     e('input', {
       type: 'text',
       list: 'speakers-list',
       placeholder: 'Спикер',
-      value: speaker,
-      onChange: ev => set('speaker', ev.target.value),
+      value: localSpeaker,
+      onChange: ev => setLocalSpeaker(ev.target.value),
       'aria-label': 'Поиск по спикеру',
     }),
     e(

--- a/frontend/hooks/useDebounce.js
+++ b/frontend/hooks/useDebounce.js
@@ -1,0 +1,12 @@
+const { useState, useEffect } = React;
+
+export function useDebounce(value, delay = 300) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
- add reusable `useDebounce` hook
- debounce query and speaker filters to limit updates

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f942e32648328b5bb1fb1c7641508