### PR TITLE
fix: normalize talk card fonts

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -466,6 +466,7 @@ body {
   box-shadow: 0 1px 6px rgba(0, 0, 0, 0.06);
   overflow: hidden;
   margin-bottom: 12px;
+  font-size: 16px;
 }
 
 .talk-card.past {
@@ -480,6 +481,13 @@ body {
   background: transparent;
   border: none;
   cursor: pointer;
+  font-size: inherit;
+}
+
+.talk-card__header .talk-title {
+  margin: 4px 0;
+  font-size: 1.25em;
+  font-weight: 600;
 }
 
 .talk-card__header .speakers strong {
@@ -498,6 +506,7 @@ body {
   padding: 16px;
   background: #111;
   color: #fff;
+  font-size: inherit;
 }
 
 .talk-card[aria-expanded="true"] .talk-card__header::after {


### PR DESCRIPTION
## Summary
- unify talk card font sizes for consistent appearance across the main page

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a060eb12f083289d1ee39a75e4d5e6