### PR TITLE
Fix talk card text overflow on main page

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -476,6 +476,14 @@ body {
   line-height: 1.4;
 }
 
+.talk-card__header,
+.talk-card__header *,
+.talk-card__details,
+.talk-card__details * {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+
 .talk-card.past {
   opacity: 0.7;
 }


### PR DESCRIPTION
## Summary
- prevent talk card text from overflowing outside screen by enabling breaking inside headers and details

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a09abf83248328bbab3b15fc22283c