### PR TITLE
Fix text overflow in talk cards

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -484,6 +484,11 @@ body {
   overflow-wrap: anywhere;
 }
 
+.talk-card__header > *,
+.talk-card__details > * {
+  min-width: 0;
+}
+
 .talk-card.past {
   opacity: 0.7;
 }


### PR DESCRIPTION
## Summary
- Prevent long strings in talk cards from expanding beyond card boundaries
- Ensure talk card content wraps properly and leaves room for the chevron

## Testing
- `npm test` (fails: Could not read package.json)
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a0a4899e10832893bad4f1d98dc296