### PR TITLE
Avoid word breaking in cards

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -95,7 +95,9 @@
 
 .admin-item-name {
   font-weight: 600;
-  word-break: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
+  hyphens: manual;
   flex: 1;
 }
 

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -480,8 +480,9 @@ body {
 .talk-card__header *,
 .talk-card__details,
 .talk-card__details * {
-  word-break: break-word;
   overflow-wrap: anywhere;
+  word-break: normal;
+  hyphens: manual;
 }
 
 .talk-card__header > *,


### PR DESCRIPTION
## Summary
- prevent words from being split inside talk cards
- allow long tokens to wrap in admin item names without hyphenation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1a27011a88328886e9e411b87059f