### PR TITLE
feat: add admin speaker filters

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -19,6 +19,17 @@
   gap: 10px;
 }
 
+.admin-speaker-filters {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.admin-speaker-filters input {
+  width: 100%;
+}
+
 .admin-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add text and tag filters to admin speakers list
- style filter controls

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check frontend/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2ce007b1883289d92a35c86392238