### PR TITLE
Show speaker talks in admin card

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -164,6 +164,15 @@
   gap: 4px;
 }
 
+.admin-speaker-talks {
+  margin-top: 8px;
+  padding-left: 20px;
+}
+
+.admin-speaker-talks li {
+  margin-bottom: 4px;
+}
+
 /* Remove background from Choices.js remove buttons to match chip color */
 .choices__item .choices__button {
   background-color: transparent !important;

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -236,6 +236,16 @@ function AdminApp() {
               e('div', { className: 'admin-tags' },
                 (s.tags || []).map(t => e('span', { key: t, className: 'admin-tag' }, t))
               ),
+              (() => {
+                const speakerTalks = talks.filter(t => (t.speakerIds || []).includes(s.id));
+                return speakerTalks.length
+                  ? e('ul', { className: 'admin-speaker-talks' },
+                      speakerTalks.map(t =>
+                        e('li', { key: t.id }, `${t.title} — ${t.eventName}`)
+                      )
+                    )
+                  : null;
+              })(),
               e('button', {
                 className: 'collapse-btn',
                 onClick: ev => { ev.stopPropagation(); toggleSpeaker(s.id); }


### PR DESCRIPTION
## Summary
- List speaker's talks with event names in admin panel
- Add styles for talk list on speaker card

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2cf03c0c88328812bda9ff0db94c7