### PR TITLE
Fix admin tag filter layout

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -155,7 +155,10 @@
 .admin-tags {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+}
+
+.admin-tags > * {
+  margin: 0 8px 8px 0;
 }
 
 .admin-tags label {


### PR DESCRIPTION
## Summary
- fix tag filter layout by using margins instead of flex gap

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2d74ad74083288a6eee4e9c827b6f