### PR TITLE
feat: improve speaker filters layout

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -21,13 +21,15 @@
 
 .admin-speaker-filters {
   display: flex;
-  flex-direction: column;
-  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
   margin-bottom: 10px;
 }
 
 .admin-speaker-filters input {
-  width: 100%;
+  flex: 1 1 200px;
+  min-width: 160px;
 }
 
 .admin-list {
@@ -155,16 +157,43 @@
 .admin-tags {
   display: flex;
   flex-wrap: wrap;
+  gap: 8px;
+  flex: 1 1 auto;
+  overflow-x: auto;
 }
 
 .admin-tags > * {
-  margin: 0 8px 8px 0;
+  margin: 0;
 }
 
-.admin-tags label {
+@media (max-width: 360px) {
+  .admin-tags {
+    flex-wrap: nowrap;
+  }
+}
+
+.filter-chip {
   display: flex;
   align-items: center;
   gap: 4px;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  background: #fff;
+  color: #000;
+  cursor: pointer;
+  white-space: nowrap;
+  min-height: 32px;
+}
+
+.filter-chip input {
+  margin: 0;
+}
+
+.filter-chip:has(input:checked) {
+  background: #000;
+  color: #fff;
+  border-color: #000;
 }
 
 .admin-speaker-talks {

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -1,5 +1,6 @@
 import { SpeakerForm, TalkForm } from './components/forms.js';
 import { TAGS } from './tags.js';
+import { useDebounce } from './hooks/useDebounce.js';
 
 const e = React.createElement;
 const { useState, useEffect } = React;
@@ -19,6 +20,7 @@ function AdminApp() {
   const [tab, setTab] = useState('speakers');
   const [error, setError] = useState(null);
   const [filterName, setFilterName] = useState('');
+  const debouncedName = useDebounce(filterName, 250);
   const [filterTags, setFilterTags] = useState([]);
 
   useEffect(() => {
@@ -167,7 +169,7 @@ function AdminApp() {
   }
 
   const filteredSpeakers = speakers.filter(s => {
-    if (filterName && !s.name.toLowerCase().includes(filterName.toLowerCase())) {
+    if (debouncedName && !s.name.toLowerCase().includes(debouncedName.toLowerCase())) {
       return false;
     }
     if (filterTags.length) {
@@ -177,21 +179,27 @@ function AdminApp() {
     return true;
   });
 
-  const speakerFilters = e('div', { className: 'admin-speaker-filters' },
+  const speakerFilters = e(
+    'div',
+    { className: 'admin-speaker-filters' },
     e('input', {
       placeholder: 'Фильтр по имени',
       value: filterName,
       onChange: ev => setFilterName(ev.target.value),
     }),
-    e('div', { className: 'admin-tags' },
+    e(
+      'div',
+      { className: 'admin-tags' },
       TAGS.map(t =>
-        e('label', { key: t },
+        e(
+          'label',
+          { key: t, className: 'filter-chip' },
           e('input', {
             type: 'checkbox',
             checked: filterTags.includes(t),
             onChange: () => toggleFilterTag(t),
           }),
-          t
+          e('span', null, t)
         )
       )
     )


### PR DESCRIPTION
## Summary
- make speaker filters responsive and render directions as chips
- highlight selected chips and debounce name search

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dcfe39448328b4a087701031828f