### PR TITLE
feat(admin): add tag multiselect filter

### DIFF
--- a/frontend/admin.css
+++ b/frontend/admin.css
@@ -27,7 +27,9 @@
   margin-bottom: 10px;
 }
 
-.admin-speaker-filters input {
+
+.admin-speaker-filters input,
+.admin-speaker-filters .choices {
   flex: 1 1 200px;
   min-width: 160px;
 }
@@ -158,43 +160,8 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  flex: 1 1 auto;
-  overflow-x: auto;
 }
 
-.admin-tags > * {
-  margin: 0;
-}
-
-@media (max-width: 360px) {
-  .admin-tags {
-    flex-wrap: nowrap;
-  }
-}
-
-.filter-chip {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  border: 1px solid #ccc;
-  border-radius: 16px;
-  background: #fff;
-  color: #000;
-  cursor: pointer;
-  white-space: nowrap;
-  min-height: 32px;
-}
-
-.filter-chip input {
-  margin: 0;
-}
-
-.filter-chip:has(input:checked) {
-  background: #000;
-  color: #fff;
-  border-color: #000;
-}
 
 .admin-speaker-talks {
   margin-top: 8px;

--- a/frontend/admin.js
+++ b/frontend/admin.js
@@ -1,6 +1,6 @@
 import { SpeakerForm, TalkForm } from './components/forms.js';
-import { TAGS } from './tags.js';
 import { useDebounce } from './hooks/useDebounce.js';
+import { TagMultiSelect } from './components/TagMultiSelect.js';
 
 const e = React.createElement;
 const { useState, useEffect } = React;
@@ -125,12 +125,6 @@ function AdminApp() {
     }
   };
 
-  const toggleFilterTag = t => {
-    setFilterTags(prev =>
-      prev.includes(t) ? prev.filter(x => x !== t) : [...prev, t]
-    );
-  };
-
   const toggleSpeaker = id => {
     setExpandedSpeakerId(expandedSpeakerId === id ? null : id);
   };
@@ -187,22 +181,7 @@ function AdminApp() {
       value: filterName,
       onChange: ev => setFilterName(ev.target.value),
     }),
-    e(
-      'div',
-      { className: 'admin-tags' },
-      TAGS.map(t =>
-        e(
-          'label',
-          { key: t, className: 'filter-chip' },
-          e('input', {
-            type: 'checkbox',
-            checked: filterTags.includes(t),
-            onChange: () => toggleFilterTag(t),
-          }),
-          e('span', null, t)
-        )
-      )
-    )
+    e(TagMultiSelect, { selected: filterTags, onChange: setFilterTags })
   );
 
   const speakerSection = editingSpeaker ?

--- a/frontend/components/TagMultiSelect.js
+++ b/frontend/components/TagMultiSelect.js
@@ -1,0 +1,54 @@
+import { TAGS } from '../tags.js';
+const e = React.createElement;
+const { useEffect, useRef } = React;
+
+export function TagMultiSelect({ selected = [], onChange }) {
+  const selectRef = useRef(null);
+  const choicesRef = useRef(null);
+
+  useEffect(() => {
+    const el = selectRef.current;
+    if (!el) return;
+
+    choicesRef.current = new Choices(el, {
+      removeItemButton: true,
+      searchEnabled: true,
+      placeholderValue: 'Теги',
+      itemSelectText: '',
+      shouldSort: false,
+    });
+
+    if (selected.length) {
+      choicesRef.current.setChoiceByValue(selected);
+    }
+
+    const handleChange = () => {
+      const values = choicesRef.current ? choicesRef.current.getValue(true) : [];
+      onChange?.(values);
+    };
+
+    el.addEventListener('change', handleChange);
+
+    return () => {
+      el.removeEventListener('change', handleChange);
+      choicesRef.current?.destroy();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!choicesRef.current) return;
+    const current = choicesRef.current.getValue(true);
+    const isSame =
+      current.length === selected.length &&
+      current.every(v => selected.includes(v));
+    if (isSame) return;
+    choicesRef.current.removeActiveItems();
+    choicesRef.current.setChoiceByValue(selected);
+  }, [selected]);
+
+  return e(
+    'select',
+    { ref: selectRef, multiple: true },
+    TAGS.map(t => e('option', { key: t, value: t }, t))
+  );
+}


### PR DESCRIPTION
## Summary
- replace checkbox tag filters with a searchable multiselect
- support tag chips with remove buttons via Choices.js
- clean up admin styles for tag selection

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2e1bacaec8328a6134a8a27e8c8fb