### PR TITLE
Add overall stats block to statistics page

### DIFF
--- a/frontend/stats.html
+++ b/frontend/stats.html
@@ -21,6 +21,11 @@
   </header>
   <main class="page__scroll">
     <div class="stats-wrapper">
+      <div class="chart-block" id="summary-block">
+        <h3 class="chart-title">Общая статистика</h3>
+        <p>Общее число спикеров: <span id="total-speakers"></span></p>
+        <p>Общее число докладов: <span id="total-talks"></span></p>
+      </div>
       <div class="chart-block">
         <h3 class="chart-title">Доклады по направлениям</h3>
         <canvas id="talks-chart"></canvas>

--- a/frontend/stats.js
+++ b/frontend/stats.js
@@ -12,10 +12,16 @@ async function loadData() {
       speakersRes.json(),
       talksRes.json()
     ]);
+    renderSummary(speakers, talks);
     renderCharts(speakers, talks);
   } catch (err) {
     document.querySelector('.stats-wrapper').innerText = 'Не удалось загрузить данные';
   }
+}
+
+function renderSummary(speakers, talks) {
+  document.getElementById('total-speakers').textContent = speakers.length;
+  document.getElementById('total-talks').textContent = talks.length;
 }
 
 function renderCharts(speakers, talks) {


### PR DESCRIPTION
## Summary
- show total number of speakers and talks at top of statistics page
- render totals when loading stats data

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a306589c2c8328b9bdb69e10245a01