### PR TITLE
feat: add event filter on home page

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -15,13 +15,14 @@ function App() {
     status: 'all',
     query: '',
     speaker: '',
+    event: '',
     from: '',
     to: '',
   });
   const [showFilters, setShowFilters] = useState(false);
   const [openedId, setOpenedId] = useState(null);
 
-  const { upcoming, past, speakers, loading, error } = useTalkData(filters);
+  const { upcoming, past, speakers, events, loading, error } = useTalkData(filters);
 
   useEffect(() => {
     const tg = window.Telegram?.WebApp;
@@ -46,6 +47,7 @@ function App() {
   const activeFilters = [];
   if (filters.query) activeFilters.push(`Название: ${filters.query}`);
   if (filters.speaker) activeFilters.push(`Спикер: ${filters.speaker}`);
+  if (filters.event) activeFilters.push(`Мероприятие: ${filters.event}`);
   if (filters.direction !== 'all') activeFilters.push(`Направление: ${filters.direction}`);
   if (filters.status !== 'all') activeFilters.push(`Статус: ${filters.status}`);
   if (filters.from) activeFilters.push(`С ${filters.from}`);
@@ -61,7 +63,7 @@ function App() {
     e(
       'div',
       { className: 'talks-scroll' },
-      e(FilterPanel, { filters, onChange: setFilters, visible: showFilters, speakers }),
+      e(FilterPanel, { filters, onChange: setFilters, visible: showFilters, speakers, events }),
       activeFilters.length > 0 &&
         e(
           'div',

--- a/frontend/components/FilterPanel.js
+++ b/frontend/components/FilterPanel.js
@@ -3,8 +3,8 @@ import { useDebounce } from '../hooks/useDebounce.js';
 const e = React.createElement;
 const { useState, useEffect } = React;
 
-export function FilterPanel({ filters, onChange, visible, speakers = [] }) {
-  const { direction, status, query, speaker, from, to } = filters;
+export function FilterPanel({ filters, onChange, visible, speakers = [], events = [] }) {
+  const { direction, status, query, speaker, from, to, event: eventName } = filters;
 
   const [localQuery, setLocalQuery] = useState(query);
   const [localSpeaker, setLocalSpeaker] = useState(speaker);
@@ -26,7 +26,7 @@ export function FilterPanel({ filters, onChange, visible, speakers = [] }) {
   }, [debouncedSpeaker, speaker]);
 
   const reset = () =>
-    onChange({ direction: 'all', status: 'all', query: '', speaker: '', from: '', to: '' });
+    onChange({ direction: 'all', status: 'all', query: '', speaker: '', event: '', from: '', to: '' });
 
   return e(
     'section',
@@ -53,6 +53,16 @@ export function FilterPanel({ filters, onChange, visible, speakers = [] }) {
       'datalist',
       { id: 'speakers-list' },
       speakers.map(s => e('option', { key: s.id, value: s.name }))
+    ),
+    e(
+      'select',
+      {
+        value: eventName,
+        onChange: ev => set('event', ev.target.value),
+        'aria-label': 'Мероприятие',
+      },
+      e('option', { value: '' }, 'Все мероприятия'),
+      events.map(evName => e('option', { key: evName, value: evName }, evName))
     ),
     e(
       'select',

--- a/frontend/hooks/useTalkData.js
+++ b/frontend/hooks/useTalkData.js
@@ -43,6 +43,7 @@ export function useTalkData(filters) {
       speaker = '',
       from = '',
       to = '',
+      event = '',
     } = filters || {};
     let list = talks.slice();
     if (direction !== 'all') list = list.filter(t => t.direction === direction);
@@ -58,6 +59,7 @@ export function useTalkData(filters) {
           .map(s => s.name.toLowerCase());
         return names.some(n => n.includes(speaker.toLowerCase()));
       });
+    if (event) list = list.filter(t => t.eventName === event);
     if (from) list = list.filter(t => new Date(t.date) >= new Date(from));
     if (to) list = list.filter(t => new Date(t.date) <= new Date(to));
     list.sort((a, b) => new Date(a.date) - new Date(b.date));
@@ -67,6 +69,11 @@ export function useTalkData(filters) {
   const now = new Date();
   const upcoming = filtered.filter(t => new Date(t.date) >= now);
   const past = filtered.filter(t => new Date(t.date) < now);
+  const events = useMemo(
+    () =>
+      Array.from(new Set(talks.map(t => t.eventName).filter(Boolean))).sort(),
+    [talks]
+  );
 
-  return { upcoming, past, speakers, loading, error };
+  return { upcoming, past, speakers, events, loading, error };
 }


### PR DESCRIPTION
## Summary
- add ability to filter talks by event on the main page
- list events from existing talks and propagate filter state

## Testing
- `node --check frontend/app.js`
- `node --check frontend/components/FilterPanel.js`
- `node --check frontend/hooks/useTalkData.js`


------
https://chatgpt.com/codex/tasks/task_e_68a309a012ac8328804fde656399e8b8